### PR TITLE
Replace potentially existing resolver files during install

### DIFF
--- a/src/puma/dev/resolver.go
+++ b/src/puma/dev/resolver.go
@@ -20,6 +20,20 @@ func ConfigureResolver(domains []string, port int) error {
 
 	for _, domain := range domains {
 		path := filepath.Join(etcDir, domain)
+
+		// Check whether there's any old resolver in place and try to remove it
+        	_, errOnFileCheck := os.Stat(path)
+
+        	if errOnFileCheck != nil {
+                	return errOnFileCheck
+        	} else {
+                	// Try to remove old resolver entries that were left by pow
+                	err := os.Remove(path)
+                	if err != nil {
+                	        return err
+        	        }
+	        }
+
 		err := ioutil.WriteFile(path, []byte(body), 0644)
 		if err != nil {
 			return err


### PR DESCRIPTION
This is in order to overcome an issue where pow might have files files installed, such as /etc/resolvers/dev.

When using `ioutil.WriteFile` during `puma-dev -install` to  write a resolver file that is owned by root and made with pow, it won’t replace the contents.

This patch tries to remove the file prior to writing to it, somewhat overcome the shortcomings of `ioutil.WriteFile`.

Fixes #39.

(PS: this is my very first few lines of Go code, please bear in mind that I'm just trying to contribute to this nice piece of software :))