### PR TITLE
Update build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ Creates links to app directories into your puma-dev directory (`~/.puma-dev` by 
 To build puma-dev, follow these steps:
 
 * Install golang (http://golang.org)
-* Install gb (http://getgb.io)
-* Run `make`
-* Run `bin/puma-dev` to use your new binary
+* Clone puma-dev to `src/github.com/puma/puma-dev` under your `gocode` directory. 
+* `cd` into the new `puma-dev` directory
+* Run `go build ./cmd/puma-dev`
+* Run `puma-dev` to use your new binary
 
-Puma-dev uses gb (http://getgb.io) to manage dependencies, so if you're working on puma-dev and need to introduce a new dependency, run `gb vendor fetch <package path>` to pull it into `vendor/src`. Then you can use it from within `puma-dev/src`


### PR DESCRIPTION
Build instructions were wrong because gb was dropped in https://github.com/puma/puma-dev/commit/7e6b4ad89b9ccd07964f69918422cd9507028ecf. I'm no Go expert so there may be a better way to write the instructions but this is what worked for me.