### PR TITLE
Falls back to the system puma if puma is not defined in the Gemfile

### DIFF
--- a/dev/app.go
+++ b/dev/app.go
@@ -245,7 +245,7 @@ if test -e .powenv; then
 	source .powenv
 fi
 
-if test -e Gemfile; then
+if test -e Gemfile && bundle show puma > /dev/null 2>&1; then
 	exec bundle exec puma -C $CONFIG --tag puma-dev:%s -w $WORKERS -t 0:$THREADS -b unix:%s
 fi
 


### PR DESCRIPTION
This is the patch described in #71. I'm currently running it on my machine and it works as expected.

The downside to this is that `bundle show puma` takes abot 0.5sec. This delay added when the app is started.

fixes #71 
