### PR TITLE
Namespace socket files to support apps with multiple symlinks

### DIFF
--- a/dev/app.go
+++ b/dev/app.go
@@ -260,7 +260,7 @@ func (pool *AppPool) LaunchApp(name, dir string) (*App, error) {
 		return nil, err
 	}
 
-	socket := filepath.Join(tmpDir, fmt.Sprintf("puma-dev-%d.sock", os.Getpid()))
+	socket := filepath.Join(tmpDir, fmt.Sprintf("puma-dev-%s-%d.sock", name, os.Getpid()))
 
 	shell := os.Getenv("SHELL")
 


### PR DESCRIPTION
We point multiple local domains at the same app to more closely match our production environment:

``` bash
$ ls -l ~/.puma-dev | grep bc3
lrwxr-xr-x  1 javan  staff  25 Sep  5 07:40 bc3 -> /Users/javan/Basecamp/bc3
lrwxr-xr-x  1 javan  staff  25 Sep  5 07:40 bc3-api -> /Users/javan/Basecamp/bc3
lrwxr-xr-x  1 javan  staff  25 Sep  6 12:14 bc3-cdn -> /Users/javan/Basecamp/bc3
```

This currently prevents puma-dev from booting all but the first because they attempt to use the same socket:

``` log
! Booting app 'bc3' on socket /Users/javan/.puma-dev/bc3/tmp/puma-dev-47750.sock
bc3[47776]: bash: no job control in this shell
bc3[47776]: Puma starting in single mode...
bc3[47776]: * Version 3.2.0 (ruby 2.3.1-p112), codename: Spring Is A Heliocentric Viewpoint
bc3[47776]: * Min threads: 0, max threads: 12
bc3[47776]: * Environment: development
bc3[47776]: * Listening on unix:/Users/javan/.puma-dev/bc3/tmp/puma-dev-47750.sock
bc3[47776]: Use Ctrl-C to stop
! App 'bc3' booted
! Booting app 'bc3-cdn' on socket /Users/javan/.puma-dev/bc3-cdn/tmp/puma-dev-47750.sock
bc3-cdn[47988]: bash: no job control in this shell
! App 'bc3-cdn' booted
bc3-cdn[47988]: Puma starting in single mode...
bc3-cdn[47988]: * Version 3.2.0 (ruby 2.3.1-p112), codename: Spring Is A Heliocentric Viewpoint
bc3-cdn[47988]: * Min threads: 0, max threads: 12
bc3-cdn[47988]: * Environment: development
bc3-cdn[47988]: * Listening on unix:/Users/javan/.puma-dev/bc3-cdn/tmp/puma-dev-47750.sock
bc3-cdn[47988]: bundler: failed to load command: puma (/Users/javan/.rbenv/versions/2.3.1/bin/puma)
bc3-cdn[47988]: RuntimeError: There is already a server bound to: /Users/javan/.puma-dev/bc3-cdn/tmp/puma-dev-47750.sock
```
