### PR TITLE
Create LaunchAgents directory if needed

### DIFF
--- a/dev/setup.go
+++ b/dev/setup.go
@@ -156,7 +156,14 @@ func InstallIntoSystem(listenPort, tlsPort int, dir, domains, timeout string) er
 
 	logPath := homedir.MustExpand("~/Library/Logs/puma-dev.log")
 
+	plistDir := homedir.MustExpand("~/Library/LaunchAgents")
 	plist := homedir.MustExpand("~/Library/LaunchAgents/io.puma.dev.plist")
+
+	err = os.MkdirAll(plistDir, 0644)
+
+	if err != nil {
+		return errors.Context(err, "creating LaunchAgent directory")
+	}
 
 	err = ioutil.WriteFile(
 		plist,


### PR DESCRIPTION
macOS doesn't create LaunchAgents directory automatically, and we need to check that before write plist.

ref: [homebrew-services](https://github.com/Homebrew/homebrew-services) [also checks and creates directory](https://github.com/Homebrew/homebrew-services/blob/master/cmd/brew-services.rb#L317).