### PR TITLE
Fallback to system puma if puma is not found in the Gemfile.lock

### DIFF
--- a/dev/app.go
+++ b/dev/app.go
@@ -245,7 +245,7 @@ if test -e .powenv; then
 	source .powenv
 fi
 
-if test -e Gemfile; then
+if test -e Gemfile && grep -q '\spuma$' Gemfile.lock; then
 	exec bundle exec puma -C $CONFIG --tag puma-dev:%s -w $WORKERS -t 0:$THREADS -b unix:%s
 fi
 


### PR DESCRIPTION
This is the solution proposed in https://github.com/puma/puma-dev/issues/71#issuecomment-255421384

Fixes #71 

Closes #72 
