### PR TITLE
Document missing development step

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ To build puma-dev, follow these steps:
 
 * Install golang (http://golang.org)
 * Run `go get github.com/puma/puma-dev/...`
+* Run `go get github.com/vektra/errors/...`
 * Run `$GOPATH/bin/puma-dev` to use your new binary
 
 Puma-dev uses gb (http://getgb.io) to manage dependencies, so if you're working on puma-dev and need to introduce a new dependency, run `gb vendor fetch <package path>` to pull it into `vendor/src`. Then you can use it from within `puma-dev/src`


### PR DESCRIPTION
Since the project now depends on github.com/vektra/errors, document this in order to avoid the following error during `make`:

```
go build ./cmd/puma-dev
cmd/puma-dev/command.go:11:2: cannot find package "github.com/vektra/errors" in any of:
	/usr/local/Cellar/go/1.7.3/libexec/src/github.com/vektra/errors (from $GOROOT)
	/usr/local/var/golang/src/github.com/vektra/errors (from $GOPATH)
make: *** [all] Error 1
```