### PR TITLE
Update message to be applicable for touch id

### DIFF
--- a/dev/ssl_darwin.go
+++ b/dev/ssl_darwin.go
@@ -11,7 +11,7 @@ const supportDir = "~/Library/Application Support/io.puma.dev"
 
 func TrustCert(cert string) error {
 	fmt.Printf("* Adding certification to login keychain as trusted\n")
-	fmt.Printf("! There is probably a dialog open that you must type your password into\n")
+	fmt.Printf("! There is probably a dialog open that requires you to authenticate\n")
 
 	login := homedir.MustExpand("~/Library/Keychains/login.keychain")
 


### PR DESCRIPTION
On the new MacBooks with Touch ID the message doesn't initially ask for your password, because authentication can be done using Touch ID:

<img width="527" alt="screen shot 2016-12-24 at 11 39 06" src="https://cloud.githubusercontent.com/assets/351038/21466474/d50efe8e-c9cd-11e6-95fe-ad5e551f1b75.png">
