### PR TITLE
Split homedir into platform-specific files

### DIFF
--- a/homedir/homedir_darwin.go
+++ b/homedir/homedir_darwin.go
@@ -1,0 +1,57 @@
+// +build darwin
+
+package homedir
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func dir() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	var stdout bytes.Buffer
+
+	// If that fails, try OS specific commands
+	cmd := exec.Command("sh", "-c", `dscl -q . -read /Users/"$(whoami)" NFSHomeDirectory | sed 's/^[^ ]*: //'`)
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err == nil {
+		result := strings.TrimSpace(stdout.String())
+		if result != "" {
+			return result, nil
+		}
+	}
+
+	// try the shell
+	stdout.Reset()
+	cmd = exec.Command("sh", "-c", "cd && pwd")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err == nil {
+		result := strings.TrimSpace(stdout.String())
+		if result != "" {
+			return result, nil
+		}
+	}
+
+	// try to figure out the user and check the default location
+	stdout.Reset()
+	cmd = exec.Command("whoami")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err == nil {
+		user := strings.TrimSpace(stdout.String())
+
+		path := "/Users/" + user
+
+		stat, err := os.Stat(path)
+		if err == nil && stat.IsDir() {
+			return path, nil
+		}
+	}
+
+	return "", ErrNoHomeDir
+}

--- a/homedir/homedir_unix.go
+++ b/homedir/homedir_unix.go
@@ -1,0 +1,62 @@
+// +build !darwin,!windows
+
+package homedir
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func dir() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	var stdout bytes.Buffer
+
+	// If that fails, try OS specific commands
+	cmd := exec.Command("getent", "passwd", strconv.Itoa(os.Getuid()))
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err == nil {
+		if passwd := strings.TrimSpace(stdout.String()); passwd != "" {
+			// username:password:uid:gid:gecos:home:shell
+			passwdParts := strings.SplitN(passwd, ":", 7)
+			if len(passwdParts) > 5 {
+				return passwdParts[5], nil
+			}
+		}
+	}
+
+	// If all else fails, try the shell
+	stdout.Reset()
+	cmd = exec.Command("sh", "-c", "cd && pwd")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err == nil {
+		result := strings.TrimSpace(stdout.String())
+		if result == "" {
+			return "", errors.New("blank output when reading home directory")
+		}
+	}
+
+	// try to figure out the user and check the default location
+	stdout.Reset()
+	cmd = exec.Command("whoami")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err == nil {
+		user := strings.TrimSpace(stdout.String())
+
+		path := "/home/" + user
+
+		stat, err := os.Stat(path)
+		if err == nil && stat.IsDir() {
+			return path, nil
+		}
+	}
+
+	return "", ErrNoHomeDir
+}

--- a/homedir/homedir_windows.go
+++ b/homedir/homedir_windows.go
@@ -1,0 +1,27 @@
+// +build windows
+
+package homedir
+
+import (
+	"errors"
+	"os"
+)
+
+func dir() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	drive := os.Getenv("HOMEDRIVE")
+	path := os.Getenv("HOMEPATH")
+	home := drive + path
+	if drive == "" || path == "" {
+		home = os.Getenv("USERPROFILE")
+	}
+	if home == "" {
+		return "", errors.New("HOMEDRIVE, HOMEPATH, and USERPROFILE are blank")
+	}
+
+	return home, nil
+}


### PR DESCRIPTION
Using [build constraints][build-constraints] means Go will only build the relevant files. This means no runtime introspection is neccessary so is a little simpler and the binaries can be slightly smaller.

  [build-constraints]: https://golang.org/pkg/go/build/#hdr-Build_Constraints