### PR TITLE
Fix checking for bundled puma executable

### DIFF
--- a/dev/app.go
+++ b/dev/app.go
@@ -247,7 +247,7 @@ if test -e .powenv; then
 	source .powenv
 fi
 
-if test -e Gemfile && grep -q '\spuma$' Gemfile.lock; then
+if test -e Gemfile && bundle exec puma -V &>/dev/null; then
 	exec bundle exec puma -C $CONFIG --tag puma-dev:%s -w $WORKERS -t 0:$THREADS -b unix:%s
 fi
 


### PR DESCRIPTION
The previous version of checking whether puma was included in the
Gemfile was prone to fail, especially if the dependency on puma included
a version condition. Now instead of grepping for puma in `Gemfile.lock`
we're testing the execution itself. The overhead should be minimal.