### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Or to proxy to another host: `echo 10.3.1.2:9292 > ~/.puma-dev/awesome-elsewhere
 
 ### HTTPS
 
-Puma-dev automatically makes the apps available via SSL as well. When you first run puma-dev, it will have likely caused a dialog to appear to put in your password. What happened there was puma-dev generates it's own CA certification that is stored in `~/Library/Application Support/io.puma.dev/cert.pem`.
+Puma-dev automatically makes the apps available via SSL as well. When you first run puma-dev, it will have likely caused a dialog to appear to put in your password. What happened there was puma-dev generates its own CA certification that is stored in `~/Library/Application Support/io.puma.dev/cert.pem`.
 
 That CA cert is used to dynamically create certificates for your apps when access to them is requested. It automatically happens, no configuration necessary. The certs are stored entirely in memory so future restarts of puma-dev simply generate new ones.
 


### PR DESCRIPTION
Love this project, have been using it for a while but just noticed a typo in the README while fixing HTTPS certificates.

`it's` -> `its`