### PR TITLE
support Bundler's renaming of Gemfile to gems.rb

### DIFF
--- a/dev/app.go
+++ b/dev/app.go
@@ -247,7 +247,7 @@ if test -e .powenv; then
 	source .powenv
 fi
 
-if test -e Gemfile && bundle exec puma -V &>/dev/null; then
+if (test -e gems.rb || test -e Gemfile) && bundle exec puma -V &>/dev/null; then
 	exec bundle exec puma -C $CONFIG --tag puma-dev:%s -w $WORKERS -t 0:$THREADS -b unix:%s
 fi
 


### PR DESCRIPTION
Bundler is starting a process to rename "Gemfile" to "gems.rb"; the new name is currently supported in  at least v1.15.4 and the old name will not be removed until v3.0. [Here is an article with more details](https://depfu.com/blog/2017/09/06/gemfiles-new-clothes).

The current 0.10 version of puma-dev only looks for "Gemfile" and so is failing to load puma for any project that has already moved to "gems.rb".