### PR TITLE
Document govendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,4 +173,4 @@ To build puma-dev, follow these steps:
 * Run `go get github.com/puma/puma-dev/...`
 * Run `$GOPATH/bin/puma-dev` to use your new binary
 
-Puma-dev uses govendor (https://github.com/kardianos/govendor) to manage dependencies, so if you're working on puma-dev and need to introduce a new dependency, run `govendor fetch +vendor <package path>` to pull it into `vendor/src`. Then you can use it from within `puma-dev/src`
+Puma-dev uses govendor (https://github.com/kardianos/govendor) to manage dependencies, so if you're working on puma-dev and need to introduce a new dependency, run `govendor fetch +vendor <package path>` to pull it into `vendor`. Then you can use it from within `puma-dev/src`

--- a/README.md
+++ b/README.md
@@ -173,4 +173,4 @@ To build puma-dev, follow these steps:
 * Run `go get github.com/puma/puma-dev/...`
 * Run `$GOPATH/bin/puma-dev` to use your new binary
 
-Puma-dev uses gb (http://getgb.io) to manage dependencies, so if you're working on puma-dev and need to introduce a new dependency, run `gb vendor fetch <package path>` to pull it into `vendor/src`. Then you can use it from within `puma-dev/src`
+Puma-dev uses govendor (https://github.com/kardianos/govendor) to manage dependencies, so if you're working on puma-dev and need to introduce a new dependency, run `govendor fetch +vendor <package path>` to pull it into `vendor/src`. Then you can use it from within `puma-dev/src`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pow's uninstall script. Read more details in [the pow manual](http://pow.cx/manu
 
 #### .dev domain
 
-Install the dev-tld-resolver (https://github.com/puma/dev-tld-resolver) to make domains resolve.
+Install the [dev-tld-resolver](https://github.com/puma/dev-tld-resolver) to make domains resolve.
 
 #### Port 80/443 binding
 
@@ -169,8 +169,8 @@ Creates links to app directories into your puma-dev directory (`~/.puma-dev` by 
 
 To build puma-dev, follow these steps:
 
-* Install golang (http://golang.org)
+* Install [golang](http://golang.org)
 * Run `go get github.com/puma/puma-dev/...`
 * Run `$GOPATH/bin/puma-dev` to use your new binary
 
-Puma-dev uses govendor (https://github.com/kardianos/govendor) to manage dependencies, so if you're working on puma-dev and need to introduce a new dependency, run `govendor fetch +vendor <package path>` to pull it into `vendor`. Then you can use it from within `puma-dev/src`
+Puma-dev uses [govendor](https://github.com/kardianos/govendor) to manage dependencies, so if you're working on puma-dev and need to introduce a new dependency, run `govendor fetch +vendor <package path>` to pull it into `vendor`. Then you can use it from within `puma-dev/src`


### PR DESCRIPTION
While setting up to work on a prototype for a feature request, I noticed that the documentation for this project is out of date with respect to `gb`. https://github.com/puma/puma-dev/commit/7e6b4ad89b9ccd07964f69918422cd9507028ecf swapped `gb` for `govendor` as the dependency management solution for this project, but the docs still mention `gb`. This PR updates the developer instructions to refer to `govendor`. 