### PR TITLE
Parse env vars for flags

### DIFF
--- a/cmd/puma-dev/main.go
+++ b/cmd/puma-dev/main.go
@@ -11,6 +11,14 @@ var fVersion = flag.Bool("V", false, "display version info")
 
 var Version = "devel"
 
+const (
+	DefaultDomains  = "dev"
+	DefaultDnsPort  = 9253
+	DefaultHttpPort = 9280
+	DefaultTlsPort  = 9283
+	DefaultDir      = "~/.puma-dev"
+)
+
 func allCheck() {
 	if *fVersion {
 		fmt.Printf("Version: %s (%s)\n", Version, runtime.Version())

--- a/cmd/puma-dev/main_darwin.go
+++ b/cmd/puma-dev/main_darwin.go
@@ -17,11 +17,11 @@ import (
 
 var (
 	fDebug    = flag.Bool("debug", false, "enable debug output")
-	fDomains  = flag.String("d", "dev", "domains to handle, separate with :")
-	fPort     = flag.Int("dns-port", 9253, "port to listen on dns for")
-	fHTTPPort = flag.Int("http-port", 9280, "port to listen on http for")
-	fTLSPort  = flag.Int("https-port", 9283, "port to listen on https for")
-	fDir      = flag.String("dir", "~/.puma-dev", "directory to watch for apps")
+	fDomains  = flag.String("d", DefaultDomains, "domains to handle, separate with :")
+	fPort     = flag.Int("dns-port", DefaultDnsPort, "port to listen on dns for")
+	fHTTPPort = flag.Int("http-port", DefaultHttpPort, "port to listen on http for")
+	fTLSPort  = flag.Int("https-port", DefaultTlsPort, "port to listen on https for")
+	fDir      = flag.String("dir", DefaultDir, "directory to watch for apps")
 	fTimeout  = flag.Duration("timeout", 15*60*time.Second, "how long to let an app idle for")
 	fPow      = flag.Bool("pow", false, "Mimic pow's settings")
 	fLaunch   = flag.Bool("launchd", false, "Use socket from launchd")
@@ -190,7 +190,7 @@ func parseEnvFlags() {
 		}
 	}
 
-	if *fDomains == "dev" {
+	if *fDomains == DefaultDomains {
 		envVal := os.Getenv("PUMA_DEV_DOMAINS")
 
 		if envVal != "" {
@@ -198,7 +198,7 @@ func parseEnvFlags() {
 		}
 	}
 
-	if *fPort == 9253 {
+	if *fPort == DefaultDnsPort {
 		envVal := os.Getenv("PUMA_DEV_DNS_PORT")
 
 		if envVal != "" {
@@ -206,7 +206,7 @@ func parseEnvFlags() {
 		}
 	}
 
-	if *fHTTPPort == 9280 {
+	if *fHTTPPort == DefaultHttpPort {
 		envVal := os.Getenv("PUMA_DEV_HTTP_PORT")
 
 		if envVal != "" {
@@ -214,7 +214,7 @@ func parseEnvFlags() {
 		}
 	}
 
-	if *fTLSPort == 9283 {
+	if *fTLSPort == DefaultTlsPort {
 		envVal := os.Getenv("PUMA_DEV_HTTPS_PORT")
 
 		if envVal != "" {
@@ -222,7 +222,7 @@ func parseEnvFlags() {
 		}
 	}
 
-	if *fDir == "~/.puma-dev" {
+	if *fDir == DefaultDir {
 		envVal := os.Getenv("PUMA_DEV_DIR")
 
 		if envVal != "" {

--- a/cmd/puma-dev/main_darwin.go
+++ b/cmd/puma-dev/main_darwin.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -31,13 +32,14 @@ var (
 	fInstall     = flag.Bool("install", false, "Install puma-dev as a user service")
 	fInstallPort = flag.Int("install-port", 80, "Port to run puma-dev on when installed")
 	fInstallTLS  = flag.Int("install-https-port", 443, "Port to run puma-dev for SSL on when installed")
-
-	fCleanup   = flag.Bool("cleanup", false, "Cleanup old system settings")
-	fUninstall = flag.Bool("uninstall", false, "Uninstall puma-dev as a user service")
+	fCleanup     = flag.Bool("cleanup", false, "Cleanup old system settings")
+	fUninstall   = flag.Bool("uninstall", false, "Uninstall puma-dev as a user service")
 )
 
 func main() {
 	flag.Parse()
+
+	parseEnvFlags()
 
 	allCheck()
 
@@ -176,5 +178,64 @@ func main() {
 	err = http.Serve(socketName)
 	if err != nil {
 		log.Fatalf("Error listening: %s", err)
+	}
+}
+
+func parseEnvFlags() {
+	if !*fDebug {
+		envVal := os.Getenv("PUMA_DEV_DEBUG")
+
+		if envVal != "" {
+			*fDebug = true
+		}
+	}
+
+	if *fDomains == "dev" {
+		envVal := os.Getenv("PUMA_DEV_DOMAINS")
+
+		if envVal != "" {
+			*fDomains = envVal
+		}
+	}
+
+	if *fPort == 9253 {
+		envVal := os.Getenv("PUMA_DEV_DNS_PORT")
+
+		if envVal != "" {
+			*fPort, _ = strconv.Atoi(envVal)
+		}
+	}
+
+	if *fHTTPPort == 9280 {
+		envVal := os.Getenv("PUMA_DEV_HTTP_PORT")
+
+		if envVal != "" {
+			*fHTTPPort, _ = strconv.Atoi(envVal)
+		}
+	}
+
+	if *fTLSPort == 9283 {
+		envVal := os.Getenv("PUMA_DEV_HTTPS_PORT")
+
+		if envVal != "" {
+			*fTLSPort, _ = strconv.Atoi(envVal)
+		}
+	}
+
+	if *fDir == "~/.puma-dev" {
+		envVal := os.Getenv("PUMA_DEV_DIR")
+
+		if envVal != "" {
+			*fDir = envVal
+		}
+	}
+
+	if *fTimeout == 15*60*time.Second {
+		envVal := os.Getenv("PUMA_DEV_TIMEOUT")
+
+		if envVal != "" {
+			parsedVal, _ := strconv.Atoi(envVal)
+			*fTimeout = time.Duration(parsedVal) * time.Second
+		}
 	}
 }

--- a/cmd/puma-dev/main_linux.go
+++ b/cmd/puma-dev/main_linux.go
@@ -28,6 +28,8 @@ var (
 func main() {
 	flag.Parse()
 
+	parseEnvFlags()
+
 	allCheck()
 
 	domains := strings.Split(*fDomains, ":")
@@ -111,5 +113,55 @@ func main() {
 	err = http.Serve()
 	if err != nil {
 		log.Fatalf("Error listening: %s", err)
+	}
+}
+
+func parseEnvFlags() {
+	if !*fDebug {
+		envVal := os.Getenv("PUMA_DEV_DEBUG")
+		if envVal != "" {
+			*fDebug = true
+		}
+	}
+
+	if *fDomains == "dev" {
+		envVal := os.Getenv("PUMA_DEV_DOMAINS")
+
+		if envVal != "" {
+			*fDomains = envVal
+		}
+	}
+
+	if *fHTTPPort == 9280 {
+		envVal := os.Getenv("PUMA_DEV_HTTP_PORT")
+
+		if envVal != "" {
+			*fHTTPPort, _ = strconv.Atoi(envVal)
+		}
+	}
+
+	if *fTLSPort == 9283 {
+		envVal := os.Getenv("PUMA_DEV_HTTPS_PORT")
+
+		if envVal != "" {
+			*fTLSPort, _ = strconv.Atoi(envVal)
+		}
+	}
+
+	if *fDir == "~/.puma-dev" {
+		envVal := os.Getenv("PUMA_DEV_DIR")
+
+		if envVal != "" {
+			*fDir = envVal
+		}
+	}
+
+	if *fTimeout == 15*60*time.Second {
+		envVal := os.Getenv("PUMA_DEV_TIMEOUT")
+
+		if envVal != "" {
+			parsedVal, _ := strconv.Atoi(envVal)
+			*fTimeout = time.Duration(parsedVal) * time.Second
+		}
 	}
 }

--- a/cmd/puma-dev/main_linux.go
+++ b/cmd/puma-dev/main_linux.go
@@ -16,11 +16,11 @@ import (
 
 var (
 	fDebug    = flag.Bool("debug", false, "enable debug output")
-	fDomains  = flag.String("d", "dev", "domains to handle, separate with :")
-	fHTTPPort = flag.Int("http-port", 9280, "port to listen on http for")
-	fTLSPort  = flag.Int("https-port", 9283, "port to listen on https for")
+	fDomains  = flag.String("d", DefaultDomains, "domains to handle, separate with :")
+	fHTTPPort = flag.Int("http-port", DefaultHttpPort, "port to listen on http for")
+	fTLSPort  = flag.Int("https-port", DefaultTlsPort, "port to listen on https for")
 	fSysBind  = flag.Bool("sysbind", false, "bind to ports 80 and 443")
-	fDir      = flag.String("dir", "~/.puma-dev", "directory to watch for apps")
+	fDir      = flag.String("dir", DefaultDir, "directory to watch for apps")
 	fTimeout  = flag.Duration("timeout", 15*60*time.Second, "how long to let an app idle for")
 	fStop     = flag.Bool("stop", false, "Stop all puma-dev servers")
 )
@@ -124,7 +124,7 @@ func parseEnvFlags() {
 		}
 	}
 
-	if *fDomains == "dev" {
+	if *fDomains == DefaultDomains {
 		envVal := os.Getenv("PUMA_DEV_DOMAINS")
 
 		if envVal != "" {
@@ -132,7 +132,7 @@ func parseEnvFlags() {
 		}
 	}
 
-	if *fHTTPPort == 9280 {
+	if *fHTTPPort == DefaultHttpPort {
 		envVal := os.Getenv("PUMA_DEV_HTTP_PORT")
 
 		if envVal != "" {
@@ -140,7 +140,7 @@ func parseEnvFlags() {
 		}
 	}
 
-	if *fTLSPort == 9283 {
+	if *fTLSPort == DefaultTlsPort {
 		envVal := os.Getenv("PUMA_DEV_HTTPS_PORT")
 
 		if envVal != "" {
@@ -148,7 +148,7 @@ func parseEnvFlags() {
 		}
 	}
 
-	if *fDir == "~/.puma-dev" {
+	if *fDir == DefaultDir {
 		envVal := os.Getenv("PUMA_DEV_DIR")
 
 		if envVal != "" {

--- a/cmd/puma-dev/main_linux.go
+++ b/cmd/puma-dev/main_linux.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"


### PR DESCRIPTION
This allows for environment-variable-based configuration in situations where a .env file might not be practical or possible. 

Initially I was looking at using https://github.com/namsral/flag, but it doesn't seem to fulfill the use case of excluding some flags from having environment variable equivalents, which seems to be a necessity here since flags are sometimes used for commands and something like `PUMA_DEV_STOP` as an environment variable doesn't make much sense.

Also, this is my first non-documentation golang PR, so apologies up front if something is totally unidiomatic.