### PR TITLE
Remove sourcing of .env

### DIFF
--- a/dev/app.go
+++ b/dev/app.go
@@ -235,10 +235,6 @@ if test -e ~/.powconfig; then
 	source ~/.powconfig
 fi
 
-if test -e .env; then
-	source .env
-fi
-
 if test -e .powrc; then
 	source .powrc
 fi


### PR DESCRIPTION
This breaks how Dotenv sources .env.* files in our Rails apps.  Dotenv will first source any .env.local, .env.development, or .env.test files before sourcing .env.  Puma-dev sources .env before Dotenv is able to source as described above, so enviroment variables found in .env.* don't "override" the same ones found in .env.

This commit is a hack to workaround this issue, and experiment with providing our own homebrew tap. We will consider opening a proper pull request to Puma-dev if there's a better approach, such as a command-line flag that'll skip all the env sourcing going on here.

Hunter provided a binary build of this PR.