### PR TITLE
Better handling of websocket headers

### DIFF
--- a/httputil/reverseproxy.go
+++ b/httputil/reverseproxy.go
@@ -179,7 +179,7 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		outreq.Header.Set("X-Forwarded-Proto", "http")
 	}
 
-	if req.Header.Get("Connection") == "Upgrade" &&
+	if strings.Contains(req.Header.Get("Connection"), "Upgrade") &&
 		req.Header.Get("Upgrade") == "websocket" {
 		p.websocketProxy(rw, outreq)
 		return


### PR DESCRIPTION
The problem is that Firefox sends a following header:

```
Connection: keep-alive, Upgrade
```

Which isn't parsed correctly by puma-dev right now, but it seems to be valid according to [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection).

Here's how websocket-driver parses it, but I think checking the suffix will be enough:

https://github.com/faye/websocket-driver-ruby/blob/ec94a219e91a0cf7968c076e67060c48d458b257/lib/websocket/driver.rb#L228

This closes #48