### PR TITLE
Use SIGTERM for shutting down apps

### DIFF
--- a/dev/app.go
+++ b/dev/app.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/puma/puma-dev/linebuffer"
@@ -86,7 +87,7 @@ func (a *App) Kill(reason string) error {
 	)
 
 	fmt.Printf("! Killing '%s' (%d)\n", a.Name, a.Command.Process.Pid)
-	err := a.Command.Process.Kill()
+	err := a.Command.Process.Signal(syscall.SIGTERM)
 	if err != nil {
 		a.eventAdd("killing_error",
 			"pid", a.Command.Process.Pid,


### PR DESCRIPTION
I believe that apps should be given the opportunity to shut down cleanly. I have a couple of apps that spawn child processes which are not shut down when `Kill` is used, which creates problems later on when they start back up. I imagine there could be other apps out there which could also use this for different purposes, like closing the connections properly, cleaning up state, etc.

The only drawback to this approach that I can see is just replacing KILL with TERM won't work in case when the process is unresponsive. So the reliable solution would be to issue TERM, wait for some time (5-10 seconds?) and then issue KILL in case process still didn't shut down. I'm wiling to implement that if this idea sounds plausible to the maintainers.

Thanks!