### PR TITLE
Update vendored fsnotify/fsevents library

### DIFF
--- a/vendor/github.com/fsnotify/fsevents/INTERNALS.md
+++ b/vendor/github.com/fsnotify/fsevents/INTERNALS.md
@@ -2,7 +2,7 @@
 
 For those new to FSEvents itself (the Apple technology), here's a really quick primer:
 
-Introduced in OS X v10.5, File System Events is made up of three parts:
+Introduced in macOS v10.5, File System Events is made up of three parts:
 
 * kernel code that passes raw event data to user space through a special device
 * a daemon that filters this stream and sends notifications
@@ -14,7 +14,7 @@ The API uses the concept of a *Stream* (FSEventStream) which is a configurable s
 
 ## Persistent Monitoring
 
-The database kept by the File System Events API allow a program that is run periodically to check for changes to the file system between runs. This has a real impact on the API and why there are parameters like `since`. This feature should be considered *advisory* according to Apple's docs - a full scan should still be run periodically. If an older version of OS X modifies the file system (say, by removing the drive and putting it in another computer) it would not update the database.
+The database kept by the File System Events API allow a program that is run periodically to check for changes to the file system between runs. This has a real impact on the API and why there are parameters like `since`. This feature should be considered *advisory* according to Apple's docs - a full scan should still be run periodically. If an older version of macOS modifies the file system (say, by removing the drive and putting it in another computer) it would not update the database.
 
 The `since` parameter must be an EventID for the host or device that the stream is for (or the special ALL or NOW values).
 
@@ -35,9 +35,9 @@ For real-time monitoring there aren't any notable advantages to a Device Stream 
 
 ## File Events
 
-Is OS X v10.7 Apple introduced *File Events* (kFSEventStreamCreateFlagFileEvents aka CF_FILEEVENTS). Prior to this events are delivered for directories only, i.e. if /tmp/subdir/testfile is modified and an FSEventStream is monitoring /tmp then an event would be delivered for the path /tmp/subdir. This tells the application that it should scan /tmp/subdir for changes. It was also possible (in corner cases) that an event for the path /tmp could be created with MUSTSCANSUBDIRS set. This should only happen if events are being dropped, and had to be coalesced to prevent the loss of information.
+Is macOS v10.7 Apple introduced *File Events* (kFSEventStreamCreateFlagFileEvents aka CF_FILEEVENTS). Prior to this events are delivered for directories only, i.e. if /tmp/subdir/testfile is modified and an FSEventStream is monitoring /tmp then an event would be delivered for the path /tmp/subdir. This tells the application that it should scan /tmp/subdir for changes. It was also possible (in corner cases) that an event for the path /tmp could be created with MUSTSCANSUBDIRS set. This should only happen if events are being dropped, and had to be coalesced to prevent the loss of information.
 
-With CF_FILEEVENTS set (>= OS X v10.7) events are generated with the path specifying the individual files that have been modified. I haven't found explicit mention, but it seems likely that the same caveats apply with respect to coalescing if events are being dropped.
+With CF_FILEEVENTS set (>= macOS v10.7) events are generated with the path specifying the individual files that have been modified. I haven't found explicit mention, but it seems likely that the same caveats apply with respect to coalescing if events are being dropped.
 
 Apple warns that using File Events will cause many more events to be generated (in part, I expect, because they don't coalesce as easily as directory-level events).
 
@@ -61,7 +61,7 @@ Instantiating an `EventStream` just allocates memory to store the *configuration
 
 ### Running a Stream
 
-In OS X an application must run a RunLoop (see: [Run Loop Management][https://developer.apple.com/library/mac/documentation/cocoa/Conceptual/Multithreading/RunLoopManagement/RunLoopManagement.html#//apple_ref/doc/uid/10000057i-CH16-SW1]) for each thread that wishes to receive events from the operating system.
+In macOS an application must run a RunLoop (see: [Run Loop Management][https://developer.apple.com/library/mac/documentation/cocoa/Conceptual/Multithreading/RunLoopManagement/RunLoopManagement.html#//apple_ref/doc/uid/10000057i-CH16-SW1]) for each thread that wishes to receive events from the operating system.
 
 An FSEventStream needs to be started, and must be supplied with a Runloop reference to deliver events to.
 

--- a/vendor/github.com/fsnotify/fsevents/README.md
+++ b/vendor/github.com/fsnotify/fsevents/README.md
@@ -1,8 +1,8 @@
-# FSEvents bindings for Go (OS X)
+# FSEvents bindings for Go (macOS)
 
-[![GoDoc](https://godoc.org/github.com/fsnotify/fsevents?status.svg)](https://godoc.org/github.com/fsnotify/fsevents)
+[![GoDoc](https://godoc.org/github.com/fsnotify/fsevents?status.svg)](https://godoc.org/github.com/fsnotify/fsevents) [![Build Status](https://travis-ci.org/fsnotify/fsevents.svg?branch=master)](https://travis-ci.org/fsnotify/fsevents) [![codecov](https://codecov.io/gh/fsnotify/fsevents/branch/master/graph/badge.svg)](https://codecov.io/gh/fsnotify/fsevents)
 
-[FSEvents](https://developer.apple.com/library/mac/documentation/Darwin/Reference/FSEvents_Ref/) allows an application to monitor a whole file system or portion of it. FSEvents is only available on OS X.
+[FSEvents](https://developer.apple.com/library/mac/documentation/Darwin/Reference/FSEvents_Ref/) allows an application to monitor a whole file system or portion of it. FSEvents is only available on macOS.
 
 **Warning:** This API should be considered unstable.
 

--- a/vendor/github.com/fsnotify/fsevents/circle.yml
+++ b/vendor/github.com/fsnotify/fsevents/circle.yml
@@ -1,0 +1,24 @@
+machine:
+  xcode:
+    version: "8.0"
+  environment:
+    XCODE_WORKSPACE: NotUsed.xcworkspace
+    XCODE_SCHEME: NotUsed
+    GOPATH: $HOME/.go_project
+    HOMEBREW_NO_AUTO_UPDATE: 1
+
+dependencies:
+  pre:
+    - brew install https://github.com/Homebrew/homebrew-core/raw/master/Formula/go.rb
+  override:
+    - sw_vers
+    - go get -u github.com/golang/lint/golint
+
+test:
+  override:
+    - go test -v -race -coverprofile=coverage.txt -covermode=atomic
+    - test -z "$(gofmt -s -l -w . | tee /dev/stderr)"
+    - test -z "$(golint ./...     | tee /dev/stderr)"
+    - go vet ./...
+  post:
+    - bash <(curl -s https://codecov.io/bash)

--- a/vendor/github.com/fsnotify/fsevents/wrap.go
+++ b/vendor/github.com/fsnotify/fsevents/wrap.go
@@ -1,0 +1,269 @@
+// +build darwin,go1.10
+
+package fsevents
+
+/*
+#cgo LDFLAGS: -framework CoreServices
+#include <CoreServices/CoreServices.h>
+#include <sys/stat.h>
+
+static CFArrayRef ArrayCreateMutable(int len) {
+	return CFArrayCreateMutable(NULL, len, &kCFTypeArrayCallBacks);
+}
+
+extern void fsevtCallback(FSEventStreamRef p0, uintptr_t info, size_t p1, char** p2, FSEventStreamEventFlags* p3, FSEventStreamEventId* p4);
+
+static FSEventStreamRef EventStreamCreateRelativeToDevice(FSEventStreamContext * context, uintptr_t info, dev_t dev, CFArrayRef paths, FSEventStreamEventId since, CFTimeInterval latency, FSEventStreamCreateFlags flags) {
+	context->info = (void*) info;
+	return FSEventStreamCreateRelativeToDevice(NULL, (FSEventStreamCallback) fsevtCallback, context, dev, paths, since, latency, flags);
+}
+
+static FSEventStreamRef EventStreamCreate(FSEventStreamContext * context, uintptr_t info, CFArrayRef paths, FSEventStreamEventId since, CFTimeInterval latency, FSEventStreamCreateFlags flags) {
+	context->info = (void*) info;
+	return FSEventStreamCreate(NULL, (FSEventStreamCallback) fsevtCallback, context, paths, since, latency, flags);
+}
+*/
+import "C"
+import (
+	"fmt"
+	"log"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"time"
+	"unsafe"
+)
+
+// eventIDSinceNow is a sentinel to begin watching events "since now".
+const eventIDSinceNow = uint64(C.kFSEventStreamEventIdSinceNow)
+
+// LatestEventID returns the most recently generated event ID, system-wide.
+func LatestEventID() uint64 {
+	return uint64(C.FSEventsGetCurrentEventId())
+}
+
+// arguments are released by C at the end of the callback. Ensure copies
+// are made if data is expected to persist beyond this function ending.
+//
+//export fsevtCallback
+func fsevtCallback(stream C.FSEventStreamRef, info uintptr, numEvents C.size_t, cpaths **C.char, cflags *C.FSEventStreamEventFlags, cids *C.FSEventStreamEventId) {
+	l := int(numEvents)
+	events := make([]Event, l)
+
+	es := registry.Get(info)
+	if es == nil {
+		log.Printf("failed to retrieve registry %d", info)
+		return
+	}
+	// These slices are backed by C data. Ensure data is copied out
+	// if it expected to exist outside of this function.
+	paths := (*[1 << 30]*C.char)(unsafe.Pointer(cpaths))[:l:l]
+	ids := (*[1 << 30]C.FSEventStreamEventId)(unsafe.Pointer(cids))[:l:l]
+	flags := (*[1 << 30]C.FSEventStreamEventFlags)(unsafe.Pointer(cflags))[:l:l]
+	for i := range events {
+		events[i] = Event{
+			Path:  C.GoString(paths[i]),
+			Flags: EventFlags(flags[i]),
+			ID:    uint64(ids[i]),
+		}
+		es.EventID = uint64(ids[i])
+	}
+
+	es.Events <- events
+}
+
+// FSEventStreamRef wraps C.FSEventStreamRef
+type FSEventStreamRef C.FSEventStreamRef
+
+// GetStreamRefEventID retrieves the last EventID from the ref
+func GetStreamRefEventID(f FSEventStreamRef) uint64 {
+	return uint64(C.FSEventStreamGetLatestEventId(f))
+}
+
+// GetStreamRefDeviceID retrieves the device ID the stream is watching
+func GetStreamRefDeviceID(f FSEventStreamRef) int32 {
+	return int32(C.FSEventStreamGetDeviceBeingWatched(f))
+}
+
+// GetStreamRefDescription retrieves debugging description information
+// about the StreamRef
+func GetStreamRefDescription(f FSEventStreamRef) string {
+	return cfStringToGoString(C.FSEventStreamCopyDescription(f))
+}
+
+// GetStreamRefPaths returns a copy of the paths being watched by
+// this stream
+func GetStreamRefPaths(f FSEventStreamRef) []string {
+	arr := C.FSEventStreamCopyPathsBeingWatched(f)
+	l := cfArrayLen(arr)
+
+	ss := make([]string, l)
+	for i := range ss {
+		void := C.CFArrayGetValueAtIndex(arr, C.CFIndex(i))
+		ss[i] = cfStringToGoString(C.CFStringRef(void))
+	}
+	return ss
+}
+
+// GetDeviceUUID retrieves the UUID required to identify an EventID
+// in the FSEvents database
+func GetDeviceUUID(deviceID int32) string {
+	uuid := C.FSEventsCopyUUIDForDevice(C.dev_t(deviceID))
+	if uuid == C.CFUUIDRef(0) {
+		return ""
+	}
+	return cfStringToGoString(C.CFUUIDCreateString(nil, uuid))
+}
+
+func cfStringToGoString(cfs C.CFStringRef) string {
+	if cfs == 0 {
+		return ""
+	}
+	cfStr := C.CFStringCreateCopy(nil, cfs)
+	length := C.CFStringGetLength(cfStr)
+	if length == 0 {
+		// short-cut for empty strings
+		return ""
+	}
+	cfRange := C.CFRange{0, length}
+	enc := C.CFStringEncoding(C.kCFStringEncodingUTF8)
+	// first find the buffer size necessary
+	var usedBufLen C.CFIndex
+	if C.CFStringGetBytes(cfStr, cfRange, enc, 0, C.false, nil, 0, &usedBufLen) == 0 {
+		return ""
+	}
+
+	bs := make([]byte, usedBufLen)
+	buf := (*C.UInt8)(unsafe.Pointer(&bs[0]))
+	if C.CFStringGetBytes(cfStr, cfRange, enc, 0, C.false, buf, usedBufLen, nil) == 0 {
+		return ""
+	}
+
+	// Create a string (byte array) backed by C byte array
+	header := (*reflect.SliceHeader)(unsafe.Pointer(&bs))
+	strHeader := &reflect.StringHeader{
+		Data: header.Data,
+		Len:  header.Len,
+	}
+	return *(*string)(unsafe.Pointer(strHeader))
+}
+
+// CFRunLoopRef wraps C.CFRunLoopRef
+type CFRunLoopRef C.CFRunLoopRef
+
+// EventIDForDeviceBeforeTime returns an event ID before a given time.
+func EventIDForDeviceBeforeTime(dev int32, before time.Time) uint64 {
+	tm := C.CFAbsoluteTime(before.Unix())
+	return uint64(C.FSEventsGetLastEventIdForDeviceBeforeTime(C.dev_t(dev), tm))
+}
+
+// createPaths accepts the user defined set of paths and returns FSEvents
+// compatible array of paths
+func createPaths(paths []string) (C.CFArrayRef, error) {
+	cPaths := C.ArrayCreateMutable(C.int(len(paths)))
+	var errs []error
+	for _, path := range paths {
+		p, err := filepath.Abs(path)
+		if err != nil {
+			// hack up some reporting errors, but don't prevent execution
+			// because of them
+			errs = append(errs, err)
+		}
+		cpath := C.CString(p)
+		defer C.free(unsafe.Pointer(cpath))
+
+		str := C.CFStringCreateWithCString(nil, cpath, C.kCFStringEncodingUTF8)
+		C.CFArrayAppendValue(C.CFMutableArrayRef(cPaths), unsafe.Pointer(str))
+	}
+	var err error
+	if len(errs) > 0 {
+		err = fmt.Errorf("%q", errs)
+	}
+	return cPaths, err
+}
+
+// CFArrayLen retrieves the length of CFArray type
+// See https://developer.apple.com/library/mac/documentation/CoreFoundation/Reference/CFArrayRef/#//apple_ref/c/func/CFArrayGetCount
+func cfArrayLen(ref C.CFArrayRef) int {
+	// FIXME: this will probably crash on 32bit, untested
+	// requires OS X v10.0
+	return int(C.CFArrayGetCount(ref))
+}
+
+func setupStream(paths []string, flags CreateFlags, callbackInfo uintptr, eventID uint64, latency time.Duration, deviceID int32) FSEventStreamRef {
+	cPaths, err := createPaths(paths)
+	if err != nil {
+		log.Printf("Error creating paths: %s", err)
+	}
+	defer C.CFRelease(C.CFTypeRef(cPaths))
+
+	since := C.FSEventStreamEventId(eventID)
+	context := C.FSEventStreamContext{}
+	info := C.uintptr_t(callbackInfo)
+	cfinv := C.CFTimeInterval(float64(latency) / float64(time.Second))
+
+	var ref C.FSEventStreamRef
+	if deviceID != 0 {
+		ref = C.EventStreamCreateRelativeToDevice(&context, info,
+			C.dev_t(deviceID), cPaths, since, cfinv,
+			C.FSEventStreamCreateFlags(flags))
+	} else {
+		ref = C.EventStreamCreate(&context, info, cPaths, since,
+			cfinv, C.FSEventStreamCreateFlags(flags))
+	}
+
+	return FSEventStreamRef(ref)
+}
+
+func (es *EventStream) start(paths []string, callbackInfo uintptr) {
+
+	since := eventIDSinceNow
+	if es.Resume {
+		since = es.EventID
+	}
+
+	es.stream = setupStream(paths, es.Flags, callbackInfo, since, es.Latency, es.Device)
+
+	started := make(chan struct{})
+
+	go func() {
+		runtime.LockOSThread()
+		es.rlref = CFRunLoopRef(C.CFRunLoopGetCurrent())
+		C.FSEventStreamScheduleWithRunLoop(es.stream, C.CFRunLoopRef(es.rlref), C.kCFRunLoopDefaultMode)
+		C.FSEventStreamStart(es.stream)
+		close(started)
+		C.CFRunLoopRun()
+	}()
+
+	if !es.hasFinalizer {
+		// TODO: There is no guarantee this run before program exit
+		// and could result in panics at exit.
+		runtime.SetFinalizer(es, finalizer)
+		es.hasFinalizer = true
+	}
+
+	<-started
+}
+
+func finalizer(es *EventStream) {
+	// If an EventStream is freed without Stop being called it will
+	// cause a panic. This avoids that, and closes the stream instead.
+	es.Stop()
+}
+
+// flush drains the event stream of undelivered events
+func flush(stream FSEventStreamRef, sync bool) {
+	if sync {
+		C.FSEventStreamFlushSync(stream)
+	} else {
+		C.FSEventStreamFlushAsync(stream)
+	}
+}
+
+// stop requests fsevents stops streaming events
+func stop(stream FSEventStreamRef, rlref CFRunLoopRef) {
+	C.FSEventStreamStop(stream)
+	C.FSEventStreamInvalidate(stream)
+	C.FSEventStreamRelease(stream)
+	C.CFRunLoopStop(C.CFRunLoopRef(rlref))
+}

--- a/vendor/github.com/fsnotify/fsevents/wrap_deprecated.go
+++ b/vendor/github.com/fsnotify/fsevents/wrap_deprecated.go
@@ -1,0 +1,276 @@
+// +build darwin,!go1.10
+
+package fsevents
+
+/*
+#cgo LDFLAGS: -framework CoreServices
+#include <CoreServices/CoreServices.h>
+#include <sys/stat.h>
+
+static CFArrayRef ArrayCreateMutable(int len) {
+	return CFArrayCreateMutable(NULL, len, &kCFTypeArrayCallBacks);
+}
+
+extern void fsevtCallback(FSEventStreamRef p0, uintptr_t info, size_t p1, char** p2, FSEventStreamEventFlags* p3, FSEventStreamEventId* p4);
+
+static FSEventStreamRef EventStreamCreateRelativeToDevice(FSEventStreamContext * context, uintptr_t info, dev_t dev, CFArrayRef paths, FSEventStreamEventId since, CFTimeInterval latency, FSEventStreamCreateFlags flags) {
+	context->info = (void*) info;
+	return FSEventStreamCreateRelativeToDevice(NULL, (FSEventStreamCallback) fsevtCallback, context, dev, paths, since, latency, flags);
+}
+
+static FSEventStreamRef EventStreamCreate(FSEventStreamContext * context, uintptr_t info, CFArrayRef paths, FSEventStreamEventId since, CFTimeInterval latency, FSEventStreamCreateFlags flags) {
+	context->info = (void*) info;
+	return FSEventStreamCreate(NULL, (FSEventStreamCallback) fsevtCallback, context, paths, since, latency, flags);
+}
+*/
+import "C"
+import (
+	"fmt"
+	"log"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"time"
+	"unsafe"
+)
+
+// eventIDSinceNow is a sentinel to begin watching events "since now".
+// NOTE: Go 1.9.2 broke compatibility here, for 1.9.1 and earlier we did:
+//   uint64(C.kFSEventStreamEventIdSinceNow + (1 << 64))
+// But 1.9.2+ complains about overflow and requires:
+//   uint64(C.kFSEventStreamEventIdSinceNow)
+// There does not seem to be an easy way to rectify, so hardcoding the value
+// here from FSEvents.h:
+//   kFSEventStreamEventIdSinceNow = 0xFFFFFFFFFFFFFFFFULL
+const eventIDSinceNow = uint64(0xFFFFFFFFFFFFFFFF)
+
+// LatestEventID returns the most recently generated event ID, system-wide.
+func LatestEventID() uint64 {
+	return uint64(C.FSEventsGetCurrentEventId())
+}
+
+// arguments are released by C at the end of the callback. Ensure copies
+// are made if data is expected to persist beyond this function ending.
+//
+//export fsevtCallback
+func fsevtCallback(stream C.FSEventStreamRef, info uintptr, numEvents C.size_t, cpaths **C.char, cflags *C.FSEventStreamEventFlags, cids *C.FSEventStreamEventId) {
+	l := int(numEvents)
+	events := make([]Event, l)
+
+	es := registry.Get(info)
+	if es == nil {
+		log.Printf("failed to retrieve registry %d", info)
+		return
+	}
+	// These slices are backed by C data. Ensure data is copied out
+	// if it expected to exist outside of this function.
+	paths := (*[1 << 30]*C.char)(unsafe.Pointer(cpaths))[:l:l]
+	ids := (*[1 << 30]C.FSEventStreamEventId)(unsafe.Pointer(cids))[:l:l]
+	flags := (*[1 << 30]C.FSEventStreamEventFlags)(unsafe.Pointer(cflags))[:l:l]
+	for i := range events {
+		events[i] = Event{
+			Path:  C.GoString(paths[i]),
+			Flags: EventFlags(flags[i]),
+			ID:    uint64(ids[i]),
+		}
+		es.EventID = uint64(ids[i])
+	}
+
+	es.Events <- events
+}
+
+// FSEventStreamRef wraps C.FSEventStreamRef
+type FSEventStreamRef C.FSEventStreamRef
+
+// GetStreamRefEventID retrieves the last EventID from the ref
+func GetStreamRefEventID(f FSEventStreamRef) uint64 {
+	return uint64(C.FSEventStreamGetLatestEventId(f))
+}
+
+// GetStreamRefDeviceID retrieves the device ID the stream is watching
+func GetStreamRefDeviceID(f FSEventStreamRef) int32 {
+	return int32(C.FSEventStreamGetDeviceBeingWatched(f))
+}
+
+// GetStreamRefDescription retrieves debugging description information
+// about the StreamRef
+func GetStreamRefDescription(f FSEventStreamRef) string {
+	return cfStringToGoString(C.FSEventStreamCopyDescription(f))
+}
+
+// GetStreamRefPaths returns a copy of the paths being watched by
+// this stream
+func GetStreamRefPaths(f FSEventStreamRef) []string {
+	arr := C.FSEventStreamCopyPathsBeingWatched(f)
+	l := cfArrayLen(arr)
+
+	ss := make([]string, l)
+	for i := range ss {
+		void := C.CFArrayGetValueAtIndex(arr, C.CFIndex(i))
+		ss[i] = cfStringToGoString(C.CFStringRef(void))
+	}
+	return ss
+}
+
+// GetDeviceUUID retrieves the UUID required to identify an EventID
+// in the FSEvents database
+func GetDeviceUUID(deviceID int32) string {
+	uuid := C.FSEventsCopyUUIDForDevice(C.dev_t(deviceID))
+	if uuid == nil {
+		return ""
+	}
+	return cfStringToGoString(C.CFUUIDCreateString(nil, uuid))
+}
+
+func cfStringToGoString(cfs C.CFStringRef) string {
+	if cfs == nil {
+		return ""
+	}
+	cfStr := C.CFStringCreateCopy(nil, cfs)
+	length := C.CFStringGetLength(cfStr)
+	if length == 0 {
+		// short-cut for empty strings
+		return ""
+	}
+	cfRange := C.CFRange{0, length}
+	enc := C.CFStringEncoding(C.kCFStringEncodingUTF8)
+	// first find the buffer size necessary
+	var usedBufLen C.CFIndex
+	if C.CFStringGetBytes(cfStr, cfRange, enc, 0, C.false, nil, 0, &usedBufLen) == 0 {
+		return ""
+	}
+
+	bs := make([]byte, usedBufLen)
+	buf := (*C.UInt8)(unsafe.Pointer(&bs[0]))
+	if C.CFStringGetBytes(cfStr, cfRange, enc, 0, C.false, buf, usedBufLen, nil) == 0 {
+		return ""
+	}
+
+	// Create a string (byte array) backed by C byte array
+	header := (*reflect.SliceHeader)(unsafe.Pointer(&bs))
+	strHeader := &reflect.StringHeader{
+		Data: header.Data,
+		Len:  header.Len,
+	}
+	return *(*string)(unsafe.Pointer(strHeader))
+}
+
+// CFRunLoopRef wraps C.CFRunLoopRef
+type CFRunLoopRef C.CFRunLoopRef
+
+// EventIDForDeviceBeforeTime returns an event ID before a given time.
+func EventIDForDeviceBeforeTime(dev int32, before time.Time) uint64 {
+	tm := C.CFAbsoluteTime(before.Unix())
+	return uint64(C.FSEventsGetLastEventIdForDeviceBeforeTime(C.dev_t(dev), tm))
+}
+
+// createPaths accepts the user defined set of paths and returns FSEvents
+// compatible array of paths
+func createPaths(paths []string) (C.CFArrayRef, error) {
+	cPaths := C.ArrayCreateMutable(C.int(len(paths)))
+	var errs []error
+	for _, path := range paths {
+		p, err := filepath.Abs(path)
+		if err != nil {
+			// hack up some reporting errors, but don't prevent execution
+			// because of them
+			errs = append(errs, err)
+		}
+		cpath := C.CString(p)
+		defer C.free(unsafe.Pointer(cpath))
+
+		str := C.CFStringCreateWithCString(nil, cpath, C.kCFStringEncodingUTF8)
+		C.CFArrayAppendValue(cPaths, unsafe.Pointer(str))
+	}
+	var err error
+	if len(errs) > 0 {
+		err = fmt.Errorf("%q", errs)
+	}
+	return cPaths, err
+}
+
+// CFArrayLen retrieves the length of CFArray type
+// See https://developer.apple.com/library/mac/documentation/CoreFoundation/Reference/CFArrayRef/#//apple_ref/c/func/CFArrayGetCount
+func cfArrayLen(ref C.CFArrayRef) int {
+	// FIXME: this will probably crash on 32bit, untested
+	// requires OS X v10.0
+	return int(C.CFArrayGetCount(ref))
+}
+
+func setupStream(paths []string, flags CreateFlags, callbackInfo uintptr, eventID uint64, latency time.Duration, deviceID int32) FSEventStreamRef {
+	cPaths, err := createPaths(paths)
+	if err != nil {
+		log.Printf("Error creating paths: %s", err)
+	}
+	defer C.CFRelease(C.CFTypeRef(cPaths))
+
+	since := C.FSEventStreamEventId(eventID)
+	context := C.FSEventStreamContext{}
+	info := C.uintptr_t(callbackInfo)
+	cfinv := C.CFTimeInterval(float64(latency) / float64(time.Second))
+
+	var ref C.FSEventStreamRef
+	if deviceID != 0 {
+		ref = C.EventStreamCreateRelativeToDevice(&context, info,
+			C.dev_t(deviceID), cPaths, since, cfinv,
+			C.FSEventStreamCreateFlags(flags))
+	} else {
+		ref = C.EventStreamCreate(&context, info, cPaths, since,
+			cfinv, C.FSEventStreamCreateFlags(flags))
+	}
+
+	return FSEventStreamRef(ref)
+}
+
+func (es *EventStream) start(paths []string, callbackInfo uintptr) {
+
+	since := eventIDSinceNow
+	if es.Resume {
+		since = es.EventID
+	}
+
+	es.stream = setupStream(paths, es.Flags, callbackInfo, since, es.Latency, es.Device)
+
+	started := make(chan struct{})
+
+	go func() {
+		runtime.LockOSThread()
+		es.rlref = CFRunLoopRef(C.CFRunLoopGetCurrent())
+		C.FSEventStreamScheduleWithRunLoop(es.stream, es.rlref, C.kCFRunLoopDefaultMode)
+		C.FSEventStreamStart(es.stream)
+		close(started)
+		C.CFRunLoopRun()
+	}()
+
+	if !es.hasFinalizer {
+		// TODO: There is no guarantee this run before program exit
+		// and could result in panics at exit.
+		runtime.SetFinalizer(es, finalizer)
+		es.hasFinalizer = true
+	}
+
+	<-started
+}
+
+func finalizer(es *EventStream) {
+	// If an EventStream is freed without Stop being called it will
+	// cause a panic. This avoids that, and closes the stream instead.
+	es.Stop()
+}
+
+// flush drains the event stream of undelivered events
+func flush(stream FSEventStreamRef, sync bool) {
+	if sync {
+		C.FSEventStreamFlushSync(stream)
+	} else {
+		C.FSEventStreamFlushAsync(stream)
+	}
+}
+
+// stop requests fsevents stops streaming events
+func stop(stream FSEventStreamRef, rlref CFRunLoopRef) {
+	C.FSEventStreamStop(stream)
+	C.FSEventStreamInvalidate(stream)
+	C.FSEventStreamRelease(stream)
+	C.CFRunLoopStop(rlref)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -16,10 +16,10 @@
 			"revisionTime": "2016-02-21T10:44:43Z"
 		},
 		{
-			"checksumSHA1": "izWnjg9a1oBPY4UBMi2REorBm68=",
+			"checksumSHA1": "xX//krtGgN0I1hxToLTIJlu11g8=",
 			"path": "github.com/fsnotify/fsevents",
-			"revision": "8b9e69e6c151001d0eb8a7cf37583265dfc6d6e4",
-			"revisionTime": "2016-05-19T18:46:26Z"
+			"revision": "ed9a50f8badcd11817e4fa3044b6765bb54219db",
+			"revisionTime": "2018-02-23T06:02:18Z"
 		},
 		{
 			"checksumSHA1": "d9PxF1XQGLMJZRct2R8qVM/eYlE=",


### PR DESCRIPTION
This pulls in https://github.com/fsnotify/fsevents/pull/34, which fixes Go 1.10+ support on mac OS.