### PR TITLE
Notes that powconfig is available for global config

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ By default, puma-dev uses the domain `.test` to manage your apps. If you want to
 
 Puma-dev supports loading environment variables before puma starts. It checks for the following files in this order:
 
+* `~/.powconfig`
 * `.env`
 * `.powrc`
 * `.powenv`


### PR DESCRIPTION
Support was added for using a `~/.powconfig` file to load configuration in 7b22ae76cac73c5a8f71dd4c56403a35c9266602, but the README was not updated to reflect that.

This change simply acknowledges the change so that others can take advantage of this.