### PR TITLE
Update README to mention support of subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ Puma-dev allows you to run multiple local domains. Handy if you're working with 
 
 Like pow, puma-dev support serving static files. If an app has a `public` directory, then any urls that match files within that directory are served. The static files have priority over the app.
 
+### Subdomains support
+
+Once a virtual host is installed, it's also automatically accessible from all subdomains of the named host. For example, a `myapp` virtual host could also be accessed at `http://www.myapp.test/` and `http://assets.www.myapp.test/`. You can override this behavior to, say, point `www.myapp.test` to a different application: just create another virtual host symlink named `www.myapp` for the application you want.
+
 ### Status API
 
 Puma-dev is starting to evolve a status API that can be used to introspect it and the apps. To access it, send a request with the `Host: puma-dev` and the path `/status`, for example: `curl -H "Host: puma-dev" localhost/status`.


### PR DESCRIPTION
I was wondering if puma-dev could support subdomains and when I tested what worked with Pow, I realized it worked exactly the same with puma-dev.

I thought this was missing in the docs so here is an extra paragraph, which is a complete [rip-off of Pow's](http://pow.cx/manual#section_2.1.1). I've also realized that _virtual host_ was not part of puma-dev vocabulary and I wondered why cause it's pretty self-explanatory and could benefit puma-dev's README as well.

Let me know what you think.