### PR TITLE
Add error messages

### DIFF
--- a/dev/dns.go
+++ b/dev/dns.go
@@ -1,6 +1,8 @@
 package dev
 
 import (
+	"fmt"
+	"log"
 	"net"
 	"sync"
 	"time"
@@ -75,13 +77,20 @@ func (d *DNSResponder) Serve(domains []string) error {
 	go func() {
 		defer wg.Done()
 		server := &dns.Server{Addr: addr, Net: "udp", TsigSecret: nil}
-		server.ListenAndServe()
+		err := server.ListenAndServe()
+		if err != nil {
+			log.Fatalf("Error serving udp DNS requests: %s", err)
+		}
+
 	}()
 
 	go func() {
 		defer wg.Done()
 		server := &dns.Server{Addr: addr, Net: "tcp", TsigSecret: nil}
-		server.ListenAndServe()
+		err := server.ListenAndServe()
+		if err != nil {
+			log.Fatalf("Error serving tcp DNS requests: %s", err)
+		}
 	}()
 
 	wg.Wait()


### PR DESCRIPTION
I was having trouble running puma-dev and adding these error messages helped me know what was going on. (In my case I had `listen tcp 127.0.0.1:9253: bind: operation not permitted` and restarting OS X fixed it.)
