### PR TITLE
Fix "not a directory"

### DIFF
--- a/dev/app.go
+++ b/dev/app.go
@@ -488,7 +488,7 @@ func (a *AppPool) App(name string) (*App, error) {
 		destPath, _ = os.Readlink(path)
 
 		if err != nil {
-			if !os.IsNotExist(err) {
+			if !os.IsNotExist(err) && err.Error() != "not a directory" {
 				return nil, err
 			}
 


### PR DESCRIPTION
I have a fake s3 service sitting behind s3.example.localhost. Buckets are often accessed via bucket.s3.example.localhost. If the bucket name includes a "-" like "bucket-name" then puma-dev tries to find ~/.puma-dev/bucket/name.s3.example.localhost which fails with the page "stat: directory not found". Apparently when a parent directory doesn't exist it is not an IsNotExist and must be handled separately. This was short-circuiting the domain fallback to s3.example.localhost etc and breaking my app.