### PR TITLE
remove application from pool on timeout

### DIFF
--- a/dev/app.go
+++ b/dev/app.go
@@ -96,6 +96,9 @@ func (a *App) Kill(reason string) error {
 			"error", err.Error(),
 		)
 		fmt.Printf("! Error trying to kill %s: %s", a.Name, err)
+	} else {
+		a.pool.remove(a)
+		a.eventAdd("shutdown")
 	}
 	return err
 }


### PR DESCRIPTION
This PR addresses https://github.com/puma/puma-dev/issues/59.

On successful `SIGTERM`, `Kill()` doesn't remove the application from the pool. As a result, on the next request, `puma-dev` thinks the app is already running and doesn't boot it. With this patch, we ensure that `puma-dev` boots a new puma process on the next request.