### PR TITLE
reorganize macOS/Linux sections of README, add make install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 bin/
 pkg/
 vendor/pkg/
+/puma-dev
+/puma-dev-*zip
+/puma-dev-*tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 all:
 	go build ./cmd/puma-dev
 
+install:
+	go install ./cmd/puma-dev
+
 release:
 	gox -os="darwin linux" -arch="amd64" -ldflags "-X main.Version=$$RELEASE" ./cmd/puma-dev
 	mv puma-dev_linux_amd64 puma-dev

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ First, ensure that the [`puma`](https://github.com/puma/puma) gem is installed. 
 
 ```ruby
 # Gemfile
-gem 'puma', '~> 4.1.0'
+gem 'puma'
 ```
 
 ### Homebrew on macOS

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Run: `puma-dev -h`
 
 You have the ability to configure most of the values that you'll use day-to-day.
 
-## Advanced Configuration
+### Advanced Configuration
 
 Puma-dev supports loading environment variables before puma starts. It checks for the following files in this order:
 
@@ -127,7 +127,7 @@ Additionally, puma-dev uses a few environment variables to control how puma is s
 * `THREADS`: How many threads puma should use concurrently. Defaults to 5.
 * `WORKERS`: How many worker processes to start. Defaults to 0, meaning only use threads.
 
-## Important Note On Ports and Domain Names
+### Important Note On Ports and Domain Names
 
 * Default privileged ports are 80 and 443
 * Default domain is `.test`.
@@ -135,11 +135,11 @@ Additionally, puma-dev uses a few environment variables to control how puma is s
   * Don't use `.dev` and `.foo`, as they are real TLDs.
 * Using pow? To avoid conflicts, use different ports and domain or [uninstall pow properly](http://pow.cx/manual.html#section_1.2).
 
-## Restarting
+### Restarting
 
 If you would like to have puma-dev restart *a specific app*, you can run `touch tmp/restart.txt` in that app's directory.
 
-## Purging
+### Purging
 
 If you would like to have puma-dev stop *all the apps* (for resource issues or because an app isn't restarting properly), you can send `puma-dev` the signal `USR1`. The easiest way to do that is:
 
@@ -217,12 +217,6 @@ The status includes:
   * If it is booting, running, or dead
   * The directory of the app
   * The last 1024 lines the app output
-
-## Subcommands
-
-### `puma-dev link [-n name] [dir]`
-
-Creates links to app directories into your puma-dev directory (`~/.puma-dev` by default).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -8,17 +8,21 @@ Puma-dev is the emotional successor to pow. It provides a quick and easy way to 
 
 * Easy startup and idle shutdown of rack/rails apps
 * Easy access to the apps using the `.test` subdomain **(configurable)**
-* Run multiple custom domains at the same time, e.g. `.test` * `.puma`.
+* Run multiple custom domains at the same time, e.g. `.test`, `.puma`.
 
 ### Why choose puma-dev?
 * __https__ - it Just Works!
 * Supports __Rails 5 actioncable__ via rack.hijack websockets
-* Supports Mac __and__ Linux
+* Supports macOS __and__ Linux
 * The honorary `pow` [is no longer maintained](https://github.com/basecamp/pow/commit/310f260d08159cf86a52df7ddb5a3bd53a94614f)
 
 ## Installation
-First, ensure that the [`puma`](https://github.com/puma/puma) gem is installed.
+First, ensure that the [`puma`](https://github.com/puma/puma) gem is installed. It probably belongs in the Gemfile of the application(s) you're trying to serve via puma-dev.
 
+```ruby
+# Gemfile
+gem 'puma', '~> 4.1.0'
+```
 
 ### Homebrew on macOS
 `brew install puma/puma/puma-dev`
@@ -41,22 +45,44 @@ make && make install
 $GOBIN/puma-dev -V
 ```
 
+------
+
 ## macOS Support
 
+### Install & Setup
+
 ```shell
-# Configure puma-dev to run in the background on ports 80 and 443 with the domain `.test`.
-puma-dev -install
 # Configure some DNS settings that have to be done as root
 sudo puma-dev -setup
+# Configure puma-dev to run in the background on ports 80 and 443 with the domain `.test`.
+puma-dev -install
 ```
+
+If you wish to have `puma-dev` use a port other than 80, pass it via the `-install-port`, for example to use port 81: `puma-dev -install -install-port 81`.
+
+*NOTE:* If you installed puma-dev v0.2, please run `sudo puma-dev -cleanup` to remove firewall rules that puma-dev no longer uses (and will conflict with puma-dev working).
 
 If you're currently using `pow`, puma-dev taking control of `.test` will break it. If you want to just try out puma-dev and leave pow working, pass `-d pdev` on `-install` to use the `.pdev` as an alternate development TLD.
 
 *NOTE:* If you had pow installed before in the system, please make sure to run pow's uninstall script. Read more details in [the pow manual](http://pow.cx/manual.html#section_1.2).
 
+### Uninstall
+
+Run: `puma-dev -uninstall`
+
+*NOTE:* If you passed custom options (e.g. `-d test:localhost`) to `-setup`, be sure to pass them to `-uninstall` as well. Otherwise `/etc/resolver/*` might contain orphaned entries.
+
+### Logging
+
+When puma-dev is installed as a user agent (the default mode), it will log output from itself and the apps to `~/Library/Logs/puma-dev.log`. You can refer to there to find out if apps have started and look for errors.
+
+In the future, puma-dev will provide an integrated console for this log output.
+
+------------
+
 ## Linux Support
 
-Puma-dev supports Linux but requires additional installation to make all the features work (e.g. Add `$HOME/.puma-dev-ssl/cert.pem` to your browser to trust CA.)
+Puma-dev supports Linux but requires additional installation to make all the features work. For example, `-install` and `-setup` flags for Linux are not provided, puma-dev root CA is generated but not installed or trusted.
 
 ### Alternate Domains (.test or similar)
 
@@ -73,54 +99,20 @@ You don't need to bind to port 80/443 to use puma-dev but obviously it makes usi
 
 There is a shortcut for binding to 80/443 by passing `-sysbind` which overrides `-http-port` and `-https-port`.
 
-### Important Note On Ports and Domain Names
+------
 
-* Default ports are 80 and 443
-* Default domain is `.test`. Previously it was `.dev`, but it is owned by Google and since Dec 2017 **HSTS only** with real websites hosted there.
-  * Don't use .dev and .foo, as they are real domains
-* Using pow? To avoid conflicts, use different ports and domain or [uninstall pow properly](http://pow.cx/manual.html#section_1.2).
+## Usage
+
+Simply symlink your app's directory into `~/.puma-dev`! That's it!
+
+You can use the built-in helper subcommand: `puma-dev link [-n name] [dir]` to link app directories into your puma-dev directory (`~/.puma-dev` by default).
 
 ### Options
-
 Run: `puma-dev -h`
 
 You have the ability to configure most of the values that you'll use day-to-day.
 
-### Setup (OS X only)
-
-Run: `sudo puma-dev -setup`.
-
-This configures the bits that require root access, which allows your user access to the `/etc/resolver` directory.
-
-### Coming from v0.2
-
-Puma-dev v0.3 and later use launchd to access privileged ports, so if you installed v0.2, you'll need to remove the firewall rules.
-
-Run: `sudo puma-dev -cleanup`
-
-### Background Install/Upgrading for port 80 access (OS X only)
-
-If you want puma-dev to run in the background while you're logged in and on a common port, then you'll need to install it.
-
-*NOTE:* If you installed puma-dev v0.2, please run `sudo puma-dev -cleanup` to remove firewall rules that puma-dev no longer uses (and will conflict with puma-dev working)
-
-Run `puma-dev -install`.
-
-If you wish to have `puma-dev` use a port other than 80, pass it via the `-install-port`, for example to use port 81: `puma-dev -install -install-port 81`.
-
-### Running in the foreground
-
-Run: `puma-dev`
-
-Puma-dev will startup by default using the directory `~/.puma-dev`, looking for symlinks to apps just like pow. Drop a symlink to your app in there as: `cd ~/.puma-dev; ln -s /path/to/my/app test`. You can now access your app as `test.test`.
-
-Running `puma-dev` in this way will require you to use the listed http port, which is `9280` by default.
-
-### Coming from Pow
-
-By default, puma-dev uses the domain `.test` to manage your apps. If you want to have puma-dev look for apps in `~/.pow`, just run `puma-dev -pow`.
-
-## Configuration
+## Advanced Configuration
 
 Puma-dev supports loading environment variables before puma starts. It checks for the following files in this order:
 
@@ -135,23 +127,41 @@ Additionally, puma-dev uses a few environment variables to control how puma is s
 * `THREADS`: How many threads puma should use concurrently. Defaults to 5.
 * `WORKERS`: How many worker processes to start. Defaults to 0, meaning only use threads.
 
+## Important Note On Ports and Domain Names
+
+* Default privileged ports are 80 and 443
+* Default domain is `.test`.
+  * Previously it was `.dev`, but it is owned by Google and since Dec 2017 **HSTS only** with real websites hosted there.
+  * Don't use `.dev` and `.foo`, as they are real TLDs.
+* Using pow? To avoid conflicts, use different ports and domain or [uninstall pow properly](http://pow.cx/manual.html#section_1.2).
+
 ## Restarting
 
-If you would like to have puma-dev restart the current app, you can run `touch tmp/restart.txt` in that apps directory.
+If you would like to have puma-dev restart *a specific app*, you can run `touch tmp/restart.txt` in that app's directory.
 
 ## Purging
 
-If you would like to have puma-dev stop all the apps (for resource issues or because an app isn't restarting properly), you can send `puma-dev` the signal `USR1`. The easiest way to do that is:
+If you would like to have puma-dev stop *all the apps* (for resource issues or because an app isn't restarting properly), you can send `puma-dev` the signal `USR1`. The easiest way to do that is:
 
 `puma-dev -stop`
 
-### Uninstall (OS X only)
+### Running in the foreground
 
-Run: `puma-dev -uninstall`
+Run: `puma-dev`
 
-## App usage
+Puma-dev will startup by default using the directory `~/.puma-dev`, looking for symlinks to apps just like pow. Drop a symlink to your app in there as: `cd ~/.puma-dev; ln -s /path/to/my/app test`. You can now access your app as `test.test`.
 
-Simply symlink your apps directory into `~/.puma-dev`! That's it!
+Running `puma-dev` in this way will require you to use the listed http port, which is `9280` by default.
+
+### Coming from v0.2
+
+Puma-dev v0.3 and later use launchd to access privileged ports, so if you installed v0.2, you'll need to remove the firewall rules.
+
+Run: `sudo puma-dev -cleanup`
+
+### Coming from Pow
+
+By default, puma-dev uses the domain `.test` to manage your apps. If you want to have puma-dev look for apps in `~/.pow`, just run `puma-dev -pow`.
 
 ### Sub Directories
 
@@ -172,12 +182,6 @@ Puma-dev automatically makes the apps available via SSL as well. When you first 
 That CA cert is used to dynamically create certificates for your apps when access to them is requested. It automatically happens, no configuration necessary. The certs are stored entirely in memory so future restarts of puma-dev simply generate new ones.
 
 When `-install` is used (and let's be honest, that's how you want to use puma-dev), then it listens on port 443 by default (configurable with `-install-https-port`) so you can just do `https://blah.test` to access your app via https.
-
-### OS X Logging
-
-When puma-dev is installed as a user agent (the default mode), it will log output from itself and the apps to `~/Library/Logs/puma-dev.log`. You can refer to there to find out if apps have started and look for errors.
-
-In the future, puma-dev will provide an integrated console for this log output.
 
 ### Websockets
 

--- a/README.md
+++ b/README.md
@@ -16,29 +16,53 @@ Puma-dev is the emotional successor to pow. It provides a quick and easy way to 
 * Supports Mac __and__ Linux
 * The honorary `pow` [is no longer maintained](https://github.com/basecamp/pow/commit/310f260d08159cf86a52df7ddb5a3bd53a94614f)
 
-## Install on macOS
+## Installation
+First, ensure that the [`puma`](https://github.com/puma/puma) gem is installed.
 
-First, install the [`puma`](https://github.com/puma/puma) gem.
 
-* Via Homebrew is the easiest: `brew install puma/puma/puma-dev`
-* Or download the latest release from https://github.com/puma/puma-dev/releases
-* If you haven't run puma-dev before, run: `sudo puma-dev -setup` to configure some DNS settings that have to be done as root
-* Run `puma-dev -install` to configure puma-dev to run in the background on ports 80 and 443 with the domain `.test`.
-  * If you're currently using pow, puma-dev taking control of `.test` will break it. If you want to just try out puma-dev and leave pow working, pass `-d pdev` on `-install` to use `.pdev` instead.
+### Homebrew on macOS
+`brew install puma/puma/puma-dev`
 
-*NOTE:* if you had pow installed before in the system, please make sure to run
-pow's uninstall script. Read more details in [the pow manual](http://pow.cx/manual.html#section_1.2).
+### Pre-built Binaries
 
-### Install on Linux
+You may download binaries for macOS and Linux at [https://github.com/puma/puma-dev/releases](https://github.com/puma/puma-dev/releases)
 
-* Puma-dev supports linux but requires additional installation to make all the features work.
-* You can either build from source or download a binary from https://github.com/puma/puma-dev/releases
+### Build from Source
 
-#### Domains (.test or similar)
+```shell
+#!/usr/bin/env bash
+
+go version
+
+go get github.com/puma/puma-dev/...
+cd $GOPATH/src/github.com/puma/puma-dev/
+make && make install
+
+$GOBIN/puma-dev -V
+```
+
+## macOS Support
+
+```shell
+# Configure puma-dev to run in the background on ports 80 and 443 with the domain `.test`.
+puma-dev -install
+# Configure some DNS settings that have to be done as root
+sudo puma-dev -setup
+```
+
+If you're currently using `pow`, puma-dev taking control of `.test` will break it. If you want to just try out puma-dev and leave pow working, pass `-d pdev` on `-install` to use the `.pdev` as an alternate development TLD.
+
+*NOTE:* If you had pow installed before in the system, please make sure to run pow's uninstall script. Read more details in [the pow manual](http://pow.cx/manual.html#section_1.2).
+
+## Linux Support
+
+Puma-dev supports Linux but requires additional installation to make all the features work (e.g. Add `$HOME/.puma-dev-ssl/cert.pem` to your browser to trust CA.)
+
+### Alternate Domains (.test or similar)
 
 Install the [dev-tld-resolver](https://github.com/puma/dev-tld-resolver) to make domains resolve.
 
-#### Port 80/443 binding
+### Port 80/443 binding
 
 There are 2 options to allow puma-dev to listen on port 80 and 443.
 


### PR DESCRIPTION
It's non-obvious how to get the `puma-dev` binary on GOPATH when building from source. It's also confusing that the Linux binary doesn't provide `-setup` or `-install` flags.

### Changes
- ignore binaries files produced by `make` and `make release`
- add `make install` to copy a built binary to `$GOBIN`
- reorganize installation / build sections of the README to distingush macOS vs Linux capabilities.

Meant to address #208 and similar questions.