### PR TITLE
Return exit code 0 (not 1) when checking the version

### DIFF
--- a/cmd/puma-dev/main.go
+++ b/cmd/puma-dev/main.go
@@ -14,7 +14,7 @@ var Version = "devel"
 func allCheck() {
 	if *fVersion {
 		fmt.Printf("Version: %s (%s)\n", Version, runtime.Version())
-		os.Exit(1)
+		os.Exit(0)
 	}
 
 	if flag.NArg() > 0 {


### PR DESCRIPTION
When checking if a program is installed and working correctly in scripts
I usually run the command (i.e. `puma-dev -V`) inside a conditional to
check if we can use it. Since `puma-dev -V` returns a non-zero (1) exit
status for the program, it can't be used like this.

This changes the version command to return a successful exit code so
that it won't block any scripts depending on the exit code of the
command.