### PR TITLE
Support nip.io domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ In the case of rails, you need to configure rails to allow all websockets or web
 
 Or you can add something like `config.action_cable.allowed_request_origins = /(\.test$)|^localhost$/` to allow anything under `.test` as well as `localhost`.
 
-### xip.io
+### xip.io/nip.io
 
-Puma-dev supports `xip.io` domains. It will detect them and strip them away, so that your `test` app can be accessed as `test.A.B.C.D.xip.io`.
+Puma-dev supports `xip.io` and `nip.io` domains. It will detect them and strip them away, so that your `test` app can be accessed as `test.A.B.C.D.xip.io`.
 
 ### Run multiple domains
 

--- a/dev/http.go
+++ b/dev/http.go
@@ -147,7 +147,7 @@ func (h *HTTPServer) removeTLD(host string) string {
 		}
 	}
 
-	if strings.HasSuffix(host, ".xip.io") {
+	if strings.HasSuffix(host, ".xip.io") || strings.HasSuffix(host, ".nip.io") {
 		parts := strings.Split(host, ".")
 		if len(parts) < 6 {
 			return ""


### PR DESCRIPTION
`nip.io` is functionally the same as `xio.io`, but some believe that `nip.io` is more reliable. It's easy to support both!