### PR TITLE
Show where app is actually located, not link name.

### DIFF
--- a/cmd/puma-dev/command.go
+++ b/cmd/puma-dev/command.go
@@ -82,7 +82,7 @@ func link() error {
 		return errors.Context(err, "creating symlink")
 	}
 
-	fmt.Printf("+ App '%s' created, linked to '%s'\n", *name, dest)
+	fmt.Printf("+ App '%s' created, linked to '%s'\n", *name, dir)
 
 	return nil
 }


### PR DESCRIPTION
I noticed that the message printed by the link command when using an alternate name was a bit confusing to me because it only mentioned the alternate name, saying it was linked to... the alternate name:
```
> puma-dev link -n api.bodaboda ~/projects/bodaboda
+ App 'api.bodaboda' created, linked to 'api.bodaboda'
```
It seems to me that it should reference the location where the symlink points to in the "linked to" text, so this PR changes the message like this:

```
> puma-dev link -n api.bodaboda ~/projects/bodaboda
+ App 'api.bodaboda' created, linked to '/users/kindjar/projects/bodaboda'
```

I think this makes more sense & is more useful?