### PR TITLE
Improve the Linux setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Puma-dev supports Linux but requires the following additional installation steps
 
 ### puma-dev root CA
 
-The puma-dev root CA is generated (in `~/.puma-dev-ssl/`), but you will need to install and trust this as a Certificate Authority.
+The puma-dev root CA is generated (in `~/.puma-dev-ssl/`), but you will need to install and trust this as a Certificate Authority by adding it to your operating system's certificate trust store, or by trusting it directly in your favored browser (as some browsers will not share the operating system's trust store).
 
 ### Domains (.test or similar)
 


### PR DESCRIPTION
As a newbie to Linux myself, I found it pretty difficult to set up, and ended up doing more things than I needed to do.

This change attempts to split out the Linux setup steps into different pieces of functionality so users can decide if they need that function, or live without it. It also adds instructions of how to set up a daemon, which comes free with Mac.

I've tried to not be too prescriptive with these steps as I'm aware that I have limited exposure to different Linux distros, so would be happy to change if there's anything here that's deemed "too ubuntu"!

Mostly following advice on https://github.com/puma/puma-dev/issues/155

