### PR TITLE
Use consistent macOS naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Puma-dev: A fast, zero-config development server for OS X and Linux
+# Puma-dev: A fast, zero-config development server for macOS and Linux
 
 [![Build Status](https://travis-ci.org/puma/puma-dev.svg?branch=master)](https://travis-ci.org/puma/puma-dev)
 
-Puma-dev is the emotional successor to pow. It provides a quick and easy way to manage apps in development on OS X and Linux.
+Puma-dev is the emotional successor to pow. It provides a quick and easy way to manage apps in development on macOS and Linux.
 
 ## Highlights
 


### PR DESCRIPTION
Replace OS X with macOS