### PR TITLE
`puma-dev link` shows proper app location with test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 
 go:
   - "1.10.x"
-  - "1.13.x"
   - master
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
   - "1.10.x"
+  - "1.13.x"
   - master
 
 os:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ all:
 install:
 	go install ./cmd/puma-dev
 
+lint:
+	find . -name '*.go' -not -wholename './vendor/*' -exec golint '{}' \;
+	golangci-lint run
+
 release:
 	gox -os="darwin linux" -arch="amd64" -ldflags "-X main.Version=$$RELEASE" ./cmd/puma-dev
 	mv puma-dev_linux_amd64 puma-dev

--- a/cmd/puma-dev/command.go
+++ b/cmd/puma-dev/command.go
@@ -82,7 +82,7 @@ func link() error {
 		return errors.Context(err, "creating symlink")
 	}
 
-	fmt.Printf("+ App '%s' created, linked to '%s'\n", *name, dest)
+	fmt.Printf("+ App '%s' created, linked to '%s'\n", *name, dir)
 
 	return nil
 }

--- a/cmd/puma-dev/command_test.go
+++ b/cmd/puma-dev/command_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	. "github.com/puma/puma-dev/dev/devtest"
+
+	"github.com/puma/puma-dev/homedir"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	EnsurePumaDevDirectory()
+	os.Exit(m.Run())
+}
+
+func TestStdoutCapture(t *testing.T) {
+	output := WithStdoutCaptured(func() {
+		fmt.Print("Hello World!")
+	})
+
+	assert.Equal(t, "Hello World!", output)
+}
+
+func TestCommand_noCommandArg(t *testing.T) {
+	StubFlagArgs(nil)
+	err := command()
+	assert.Equal(t, "Unknown command: \n", err.Error())
+}
+
+func TestCommand_badCommandArg(t *testing.T) {
+	StubFlagArgs([]string{"doesnotexist"})
+	err := command()
+	assert.Equal(t, "Unknown command: doesnotexist\n", err.Error())
+}
+
+func TestCommand_link_noArgs(t *testing.T) {
+	StubFlagArgs([]string{"link"})
+
+	appDir, _ := homedir.Expand("~/my-test-puma-dev-application")
+
+	WithWorkingDirectory(appDir, true, func() {
+		actual := WithStdoutCaptured(func() {
+			if err := command(); err != nil {
+				assert.Fail(t, err.Error())
+			}
+		})
+
+		expected := fmt.Sprintf("+ App 'my-test-puma-dev-application' created, linked to '%s'\n", appDir)
+		assert.Equal(t, expected, actual)
+	})
+
+	RemoveAppSymlinkOrFail(t, "my-test-puma-dev-application")
+}
+
+func TestCommand_link_withNameOverride(t *testing.T) {
+	tmpCwd := "/tmp/puma-dev-example-command-link-noargs"
+
+	StubFlagArgs([]string{"link", "-n", "anothername", tmpCwd})
+
+	WithWorkingDirectory(tmpCwd, true, func() {
+		actual := WithStdoutCaptured(func() {
+			if err := command(); err != nil {
+				assert.Fail(t, err.Error())
+			}
+		})
+
+		assert.Equal(t, "+ App 'anothername' created, linked to '/tmp/puma-dev-example-command-link-noargs'\n", actual)
+	})
+
+	RemoveAppSymlinkOrFail(t, "anothername")
+}
+
+func TestCommand_link_invalidDirectory(t *testing.T) {
+	StubFlagArgs([]string{"link", "/this/path/does/not/exist"})
+
+	err := command()
+
+	assert.Equal(t, "Invalid directory: /this/path/does/not/exist", err.Error())
+}
+
+func TestCommand_link_reassignExistingApp(t *testing.T) {
+	appAlias := "apptastic"
+	appDir1 := MakeDirectoryOrFail(t, "/tmp/puma-dev-test-command-link-reassign-existing-app-one")
+	appDir2 := MakeDirectoryOrFail(t, "/tmp/puma-dev-test-command-link-reassign-existing-app-two")
+
+	defer RemoveDirectoryOrFail(t, appDir1)
+	defer RemoveDirectoryOrFail(t, appDir2)
+	defer RemoveAppSymlinkOrFail(t, appAlias)
+
+	StubFlagArgs([]string{"link", "-n", appAlias, appDir1})
+	actual1 := WithStdoutCaptured(func() {
+		if err := command(); err != nil {
+			assert.Fail(t, err.Error())
+		}
+	})
+
+	assert.Equal(t, fmt.Sprintf("+ App '%s' created, linked to '%s'\n", appAlias, appDir1), actual1)
+
+	StubFlagArgs([]string{"link", "-n", appAlias, appDir2})
+	actual2 := WithStdoutCaptured(func() {
+		if err := command(); err != nil {
+			assert.Fail(t, err.Error())
+		}
+	})
+
+	assert.Equal(t, fmt.Sprintf("! App '%s' already exists, pointed at '%s'\n", appAlias, appDir1), actual2)
+}

--- a/cmd/puma-dev/command_test.go
+++ b/cmd/puma-dev/command_test.go
@@ -16,14 +16,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestStdoutCapture(t *testing.T) {
-	output := WithStdoutCaptured(func() {
-		fmt.Print("Hello World!")
-	})
-
-	assert.Equal(t, "Hello World!", output)
-}
-
 func TestCommand_noCommandArg(t *testing.T) {
 	StubFlagArgs(nil)
 	err := command()

--- a/cmd/puma-dev/command_test.go
+++ b/cmd/puma-dev/command_test.go
@@ -33,7 +33,7 @@ func TestCommand_link_noArgs(t *testing.T) {
 
 	appDir, _ := homedir.Expand("~/my-test-puma-dev-application")
 
-	WithWorkingDirectory(appDir, true, func() {
+	WithWorkingDirectory(appDir, func() {
 		actual := WithStdoutCaptured(func() {
 			if err := command(); err != nil {
 				assert.Fail(t, err.Error())
@@ -52,7 +52,7 @@ func TestCommand_link_withNameOverride(t *testing.T) {
 
 	StubFlagArgs([]string{"link", "-n", "anothername", tmpCwd})
 
-	WithWorkingDirectory(tmpCwd, true, func() {
+	WithWorkingDirectory(tmpCwd, func() {
 		actual := WithStdoutCaptured(func() {
 			if err := command(); err != nil {
 				assert.Fail(t, err.Error())

--- a/dev/devtest/testutils.go
+++ b/dev/devtest/testutils.go
@@ -1,0 +1,119 @@
+package devtest
+
+import (
+	"bytes"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/puma/puma-dev/homedir"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	appSymlinkHome = "~/.puma-dev"
+)
+
+// StubFlagArgs overrides command arguments to pretend as if puma-dev was executed at the commandline.
+// ex: StubArgFlags([]string{"-n", "myapp", "path/to/app"}) ->
+//   $ puma-dev -n myapp path/to/app
+func StubFlagArgs(args []string) {
+	os.Args = append([]string{"puma-dev"}, args...)
+	flag.Parse()
+}
+
+// EnsurePumaDevDirectory creates ~/.puma-dev if it does not already exist.
+func EnsurePumaDevDirectory() {
+	path, err := homedir.Expand(appSymlinkHome)
+
+	if err != nil {
+		panic(err)
+	}
+
+	if fi, err := os.Stat(path); err == nil && fi.IsDir() {
+		return
+	}
+
+	if err := os.Mkdir(path, 0755); err != nil {
+		panic(err)
+	}
+}
+
+// WithStdoutCaptured executes the passed function and returns a string containing the stdout of the executed function.
+func WithStdoutCaptured(f func()) string {
+	osStdout := os.Stdout
+	r, w, err := os.Pipe()
+
+	if err != nil {
+		panic(err)
+	}
+
+	os.Stdout = w
+
+	outC := make(chan string)
+
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		outC <- buf.String()
+	}()
+
+	f()
+
+	w.Close()
+	os.Stdout = osStdout
+	out := <-outC
+
+	return out
+}
+
+// RemoveDirectoryOrFail removes a directory (and its contents) or fails the test.
+func RemoveDirectoryOrFail(t *testing.T, path string) {
+	if err := os.RemoveAll(path); err != nil {
+		assert.Fail(t, err.Error())
+	}
+}
+
+// MakeDirectoryOrFail makes a directory or fails the test, returning the path of the directory that was created.
+func MakeDirectoryOrFail(t *testing.T, path string) string {
+	if err := os.Mkdir(path, 0755); err != nil {
+		assert.Fail(t, err.Error())
+	}
+	return path
+}
+
+// WithWorkingDirectory executes the passed function within the context of
+// the passed working directory path.
+func WithWorkingDirectory(path string, mkdir bool, f func()) {
+	// deleteDirectoryAfterwards := false
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		if mkdir == true {
+			os.Mkdir(path, 0755)
+		} else {
+			panic(err)
+		}
+	}
+
+	originalPath, _ := os.Getwd()
+	os.Chdir(path)
+	f()
+	os.Chdir(originalPath)
+}
+
+// RemoveAppSymlinkOrFail deletes a symlink at ~/.puma-dev/{name} or fails the test.
+func RemoveAppSymlinkOrFail(t *testing.T, name string) {
+	path, err := homedir.Expand(filepath.Join(appSymlinkHome, name))
+	if err != nil {
+		panic(err)
+	}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return
+	}
+
+	if err := os.Remove(path); err != nil {
+		panic(err)
+	}
+}

--- a/dev/launch/launch.go
+++ b/dev/launch/launch.go
@@ -1,3 +1,5 @@
+// +build darwin
+
 package launch
 
 /* Lovingly borrowed from https://github.com/sstephenson/launch_socket_server/blob/master/src/launch/socket.go */

--- a/homedir/homedir.go
+++ b/homedir/homedir.go
@@ -1,3 +1,5 @@
+// https://github.com/mitchellh/go-homedir
+
 package homedir
 
 import (


### PR DESCRIPTION
This PR adds test coverage for functionality introduced in https://github.com/puma/puma-dev/pull/218 by @kindjar.

### Changes
- [x] `puma-dev link` success message contains the full path of the new app symlink, rather than printing the app name twice. (h/t @kindjar)
- [x] Add make target to run linters (`make lint`). Might be worth it to open a new issue to address linter errors.
- [x] Add `devtest/testutils.go` to provide handy functionality for tests including stdout capture, CLI flag manipulation, PWD faking, and more.
- [x] Add `main/command_test.go` to cover changes to `command.go`.

### Original PR Description

> I noticed that the message printed by the link command when using an alternate name was a bit confusing to me because it only mentioned the alternate name, saying it was linked to... the alternate name:
> 
> ```
> > puma-dev link -n api.bodaboda ~/projects/bodaboda
> + App 'api.bodaboda' created, linked to 'api.bodaboda'
> ```
> 
> It seems to me that it should reference the location where the symlink points to in the "linked to" text, so this PR changes the message like this:
> 
> ```
> > puma-dev link -n api.bodaboda ~/projects/bodaboda
> + App 'api.bodaboda' created, linked to '/users/kindjar/projects/bodaboda'
> ```
> 
> I think this makes more sense & is more useful?

