### PR TITLE
Output Status of Running Applications

### DIFF
--- a/cmd/puma-dev/command.go
+++ b/cmd/puma-dev/command.go
@@ -26,6 +26,7 @@ func command() error {
 	}
 }
 
+// App is a running application.
 type App struct {
 	Status  string `json:"status"`
 	Scheme  string `json:"scheme"`
@@ -33,8 +34,15 @@ type App struct {
 }
 
 func status() error {
+	var port string
+
+	if *fHTTPPort != 9280 {
+		port = fmt.Sprintf(":%d", *fHTTPPort)
+	}
+
 	client := &http.Client{}
-	req, err := http.NewRequest("GET", "http://localhost/status", nil)
+	url := fmt.Sprintf("http://localhost%s/status", port)
+	req, err := http.NewRequest("GET", url, nil)
 	req.Host = "puma-dev"
 	w := tabwriter.NewWriter(os.Stdout, 20, 4, 1, ' ', 0)
 
@@ -45,7 +53,7 @@ func status() error {
 	res, err := client.Do(req)
 
 	if err != nil {
-		fmt.Println("puma-dev is not running")
+		fmt.Printf("Unable to lookup puma-dev status. Is puma-dev listening on port %d?\n", *fHTTPPort)
 		return nil
 	}
 

--- a/cmd/puma-dev/command.go
+++ b/cmd/puma-dev/command.go
@@ -45,7 +45,8 @@ func status() error {
 	res, err := client.Do(req)
 
 	if err != nil {
-		return err
+		fmt.Println("puma-dev is not running")
+		return nil
 	}
 
 	body, err := ioutil.ReadAll(res.Body)

--- a/cmd/puma-dev/command_test.go
+++ b/cmd/puma-dev/command_test.go
@@ -97,3 +97,7 @@ func TestCommand_link_reassignExistingApp(t *testing.T) {
 
 	RemoveAppSymlinkOrFail(t, appAlias)
 }
+
+func TestCommand_status(t *testing.T) {
+	assert.Nil(t, status())
+}

--- a/cmd/puma-dev/main.go
+++ b/cmd/puma-dev/main.go
@@ -52,6 +52,6 @@ func init() {
 		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
 		flag.PrintDefaults()
 
-		fmt.Fprintf(os.Stderr, "\nAvailable subcommands: link\n")
+		fmt.Fprintf(os.Stderr, "\nAvailable subcommands: link, status\n")
 	}
 }


### PR DESCRIPTION
Add a `puma-dev status` sub-command to output the status of all
applications currently running through `puma-dev`. Uses the Status API
requested from `http://localhost/status` with `Host: "puma-dev"`.

Fixes #222