### PR TITLE
Travis CI: Go 1.13, previously 1.10 which didn't support modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.10.x"
+  - "1.13.x"
   - master
 
 os:


### PR DESCRIPTION
https://travis-ci.org/puma/puma-dev/builds/647170075 for #226 failed due to an old version of Go running in CI; Go 1.10 (early 2018) did not support [Go Modules](https://github.com/golang/go/wiki/Modules).

This PR upgrades Ci pipeline to Go 1.13, which is very stable after shipping in September 2019; https://golang.org/doc/devel/release.html