### PR TITLE
allow travis-ci to build forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
 
+go_import_path: github.com/puma/puma-dev
+
 go:
   - "1.13.x"
   - master


### PR DESCRIPTION
Because `puma-dev` includes an internal package, travis won't build forks because it thinks they're not allowed to reference an "external" internal package. This makes working on PRs a bit tricky.

This PR explicitly sets the `go_import_path` for TravisCI so it will allow forks like `i-am-not-puma/puma-dev` to build by allowing internal imports.

Example build failure _before_ this change:
<img src=https://user-images.githubusercontent.com/550903/74059799-adfaed00-49b6-11ea-9740-a3162f706d91.png width=800>

