### PR TITLE
Add support for nip.io with test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,9 @@ In the case of rails, you need to configure rails to allow all websockets or web
 
 Or you can add something like `config.action_cable.allowed_request_origins = /(\.test$)|^localhost$/` to allow anything under `.test` as well as `localhost`.
 
-### xip.io
+### xip.io/nip.io
 
-Puma-dev supports `xip.io` domains. It will detect them and strip them away, so that your `test` app can be accessed as `test.A.B.C.D.xip.io`.
+Puma-dev supports `xip.io` and `nip.io` domains. It will detect them and strip them away, so that your `test` app can be accessed as `test.A.B.C.D.xip.io`.
 
 ### Run multiple domains
 

--- a/dev/http.go
+++ b/dev/http.go
@@ -147,7 +147,7 @@ func (h *HTTPServer) removeTLD(host string) string {
 		}
 	}
 
-	if strings.HasSuffix(host, ".xip.io") {
+	if strings.HasSuffix(host, ".xip.io") || strings.HasSuffix(host, ".nip.io") {
 		parts := strings.Split(host, ".")
 		if len(parts) < 6 {
 			return ""

--- a/dev/http.go
+++ b/dev/http.go
@@ -104,41 +104,6 @@ func (h *HTTPServer) findApp(name string) (*App, error) {
 	return app, nil
 }
 
-func (h *HTTPServer) hostForApp(name string) (string, string, error) {
-	var (
-		app *App
-		err error
-	)
-
-	for name != "" {
-		app, err = h.Pool.App(name)
-		if err != nil {
-			if err == ErrUnknownApp {
-				name = pruneSub(name)
-				continue
-			}
-
-			return "", "", err
-		}
-
-		break
-	}
-
-	if app == nil {
-		app, err = h.Pool.App("default")
-		if err != nil {
-			return "", "", err
-		}
-	}
-
-	err = app.WaitTilReady()
-	if err != nil {
-		return "", "", err
-	}
-
-	return app.Scheme, app.Address(), nil
-}
-
 func (h *HTTPServer) removeTLD(host string) string {
 	colon := strings.LastIndexByte(host, ':')
 	if colon != -1 {

--- a/dev/http_test.go
+++ b/dev/http_test.go
@@ -1,0 +1,35 @@
+package dev
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/puma/puma-dev/dev/devtest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var testHttp HTTPServer
+
+func TestMain(m *testing.M) {
+	EnsurePumaDevDirectory()
+	os.Exit(m.Run())
+}
+
+func TestHttp_removeTLD_test(t *testing.T) {
+	str := testHttp.removeTLD("psychic-octo-giggle.test")
+
+	assert.Equal(t, "psychic-octo-giggle", str)
+}
+
+func TestHttp_removeTLD_xipIoDots(t *testing.T) {
+	str := testHttp.removeTLD("legendary-meme.0.0.0.0.xip.io")
+
+	assert.Equal(t, "legendary-meme", str)
+}
+
+func TestHttp_removeTLD_nipIoDots(t *testing.T) {
+	str := testHttp.removeTLD("effective-invention.255.255.255.255.nip.io")
+
+	assert.Equal(t, "effective-invention", str)
+}

--- a/dev/http_test.go
+++ b/dev/http_test.go
@@ -1,20 +1,12 @@
 package dev
 
 import (
-	"os"
 	"testing"
-
-	. "github.com/puma/puma-dev/dev/devtest"
 
 	"github.com/stretchr/testify/assert"
 )
 
 var testHttp HTTPServer
-
-func TestMain(m *testing.M) {
-	EnsurePumaDevDirectory()
-	os.Exit(m.Run())
-}
 
 func TestHttp_removeTLD_test(t *testing.T) {
 	str := testHttp.removeTLD("psychic-octo-guide.test")

--- a/dev/http_test.go
+++ b/dev/http_test.go
@@ -17,9 +17,33 @@ func TestMain(m *testing.M) {
 }
 
 func TestHttp_removeTLD_test(t *testing.T) {
-	str := testHttp.removeTLD("psychic-octo-giggle.test")
+	str := testHttp.removeTLD("psychic-octo-guide.test")
 
-	assert.Equal(t, "psychic-octo-giggle", str)
+	assert.Equal(t, "psychic-octo-guide", str)
+}
+
+func TestHttp_removeTLD_noTld(t *testing.T) {
+	str := testHttp.removeTLD("shiny-train")
+
+	assert.Equal(t, "shiny-train", str)
+}
+
+func TestHttp_removeTLD_mutlipartDomain(t *testing.T) {
+	str := testHttp.removeTLD("expert-eureka.loc.al")
+
+	assert.Equal(t, "expert-eureka.loc", str)
+}
+
+func TestHttp_removeTLD_dev(t *testing.T) {
+	str := testHttp.removeTLD("bookish-giggle.dev:8080")
+
+	assert.Equal(t, "bookish-giggle", str)
+}
+
+func TestHttp_removeTLD_xipIoMalformed(t *testing.T) {
+	str := testHttp.removeTLD("legendary-meme.0.0.xip.io")
+
+	assert.Equal(t, "", str)
 }
 
 func TestHttp_removeTLD_xipIoDots(t *testing.T) {

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac/go.mod h1:8rLXio+Wji
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsevents v0.1.0 h1:qeALFWR0ZE27D78Zq8mYxCF/5YrioLzrddiDz5pbR7c=
 github.com/fsnotify/fsevents v0.1.0/go.mod h1:+d+hS27T6k5J8CRaPLKFgwKYcpS7GwW3Ule9+SC2ZRc=
 github.com/hashicorp/golang-lru v0.0.0-20160207214719-a0d98a5f2880 h1:OaRuzt9oCKNui8cCskZijoKUwe+aCuuCwvx1ox8FNyw=
 github.com/hashicorp/golang-lru v0.0.0-20160207214719-a0d98a5f2880/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=


### PR DESCRIPTION
This PR completes the intent expressed in https://github.com/puma/puma-dev/pull/214.

## Changes
1. Process `nip.io` like `xip.io`, assuming a format like `appname.1.2.3.4.nip.io` to discover the app name. (h/t @jeremy-ebler-vineti)
1. Add `http_test.go` w/ test cases for `HTTPServer#removeTLD(string)`
1. Remove unused method in `http.go`

## Testing
I didn't encounter the same proxying problem that @jeremy-ebler-vineti reported. I was able to resolve puma-dev via nip.io with this PR applied.

```
puma-dev$ git rev-parse HEAD; make; make install; which puma-dev; puma-dev -V
38f4895f5960d4f06e36a0b7f0d142c2dc4f6a55
go build ./cmd/puma-dev
go install ./cmd/puma-dev
/Users/nonrational/go/1.13.7/bin/puma-dev
Version: devel (go1.13.7)
puma-dev$ sudo puma-dev -d test:localhost:loc.al -setup
* Configuring /etc/resolver to be owned by nonrational
* Changing '/etc/resolver/loc.al' to be owned by nonrational
* Changing '/etc/resolver/localhost' to be owned by nonrational
* Changing '/etc/resolver/test' to be owned by nonrational
puma-dev$ puma-dev -d test:localhost:loc.al -install
* Use '/Users/nonrational/go/1.13.7/bin/puma-dev' as the location of puma-dev
* Installed puma-dev on ports: http 80, https 443

~$ readlink ~/.puma-dev/red-moon-cow
/Users/nonrational/src/red-moon-cow
~$ curl -v --silent red-moon-cow.loc.al 2>&1 | egrep '< HTTP'
< HTTP/1.1 200 OK
~$ curl -v --silent red-moon-cow.127.0.0.1.nip.io 2>&1 | egrep '< HTTP'
< HTTP/1.1 200 OK
~$ curl -v --silent red-moon-cow.192.168.2.105.nip.io 2>&1 | egrep '< HTTP'
< HTTP/1.1 200 OK
~$ curl -v --silent doesnotexist.192.168.2.105.nip.io 2>&1 | egrep '< HTTP'
< HTTP/1.1 500 Internal Server Error
```
