### PR TITLE
`puma-dev -V` exits with status 0 (not 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/pkg/
 /puma-dev-*zip
 /puma-dev-*tar.gz
 /tmp
+coverage.out

--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,17 @@ release:
 test:
 	go test -v ./...
 
+coverage:
+	go test -coverprofile=coverage.out -v ./...
+	go tool cover -html=coverage.out
+
 .PHONY: all release
+
+PACKAGES = $(shell find ./ -type d -not -path '*/\.*')
+
+test-cover-html:
+	echo "mode: count" > coverage-all.out
+	$(foreach pkg,$(PACKAGES),\
+		go test -coverprofile=coverage.out $(pkg);\
+		tail -n +2 coverage.out >> coverage-all.out;)
+	go tool cover -html=coverage-all.out

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,3 @@ coverage:
 	go tool cover -html=coverage.out
 
 .PHONY: all release
-
-PACKAGES = $(shell find ./ -type d -not -path '*/\.*')
-
-test-cover-html:
-	echo "mode: count" > coverage-all.out
-	$(foreach pkg,$(PACKAGES),\
-		go test -coverprofile=coverage.out $(pkg);\
-		tail -n +2 coverage.out >> coverage-all.out;)
-	go tool cover -html=coverage-all.out

--- a/cmd/puma-dev/command_test.go
+++ b/cmd/puma-dev/command_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	. "github.com/puma/puma-dev/dev/devtest"
@@ -10,11 +9,6 @@ import (
 	"github.com/puma/puma-dev/homedir"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestMain(m *testing.M) {
-	EnsurePumaDevDirectory()
-	os.Exit(m.Run())
-}
 
 func TestCommand_noCommandArg(t *testing.T) {
 	StubCommandLineArgs(nil)

--- a/cmd/puma-dev/command_test.go
+++ b/cmd/puma-dev/command_test.go
@@ -17,19 +17,19 @@ func TestMain(m *testing.M) {
 }
 
 func TestCommand_noCommandArg(t *testing.T) {
-	StubFlagArgs(nil)
+	StubCommandLineArgs(nil)
 	err := command()
 	assert.Equal(t, "Unknown command: \n", err.Error())
 }
 
 func TestCommand_badCommandArg(t *testing.T) {
-	StubFlagArgs([]string{"doesnotexist"})
+	StubCommandLineArgs([]string{"doesnotexist"})
 	err := command()
 	assert.Equal(t, "Unknown command: doesnotexist\n", err.Error())
 }
 
 func TestCommand_link_noArgs(t *testing.T) {
-	StubFlagArgs([]string{"link"})
+	StubCommandLineArgs([]string{"link"})
 
 	appDir, _ := homedir.Expand("~/my-test-puma-dev-application")
 
@@ -50,7 +50,7 @@ func TestCommand_link_noArgs(t *testing.T) {
 func TestCommand_link_withNameOverride(t *testing.T) {
 	tmpCwd := "/tmp/puma-dev-example-command-link-noargs"
 
-	StubFlagArgs([]string{"link", "-n", "anothername", tmpCwd})
+	StubCommandLineArgs([]string{"link", "-n", "anothername", tmpCwd})
 
 	WithWorkingDirectory(tmpCwd, func() {
 		actual := WithStdoutCaptured(func() {
@@ -66,7 +66,7 @@ func TestCommand_link_withNameOverride(t *testing.T) {
 }
 
 func TestCommand_link_invalidDirectory(t *testing.T) {
-	StubFlagArgs([]string{"link", "/this/path/does/not/exist"})
+	StubCommandLineArgs([]string{"link", "/this/path/does/not/exist"})
 
 	err := command()
 
@@ -82,7 +82,7 @@ func TestCommand_link_reassignExistingApp(t *testing.T) {
 	defer RemoveDirectoryOrFail(t, appDir2)
 	defer RemoveAppSymlinkOrFail(t, appAlias)
 
-	StubFlagArgs([]string{"link", "-n", appAlias, appDir1})
+	StubCommandLineArgs([]string{"link", "-n", appAlias, appDir1})
 	actual1 := WithStdoutCaptured(func() {
 		if err := command(); err != nil {
 			assert.Fail(t, err.Error())
@@ -91,7 +91,7 @@ func TestCommand_link_reassignExistingApp(t *testing.T) {
 
 	assert.Equal(t, fmt.Sprintf("+ App '%s' created, linked to '%s'\n", appAlias, appDir1), actual1)
 
-	StubFlagArgs([]string{"link", "-n", appAlias, appDir2})
+	StubCommandLineArgs([]string{"link", "-n", appAlias, appDir2})
 	actual2 := WithStdoutCaptured(func() {
 		if err := command(); err != nil {
 			assert.Fail(t, err.Error())

--- a/cmd/puma-dev/command_test.go
+++ b/cmd/puma-dev/command_test.go
@@ -11,19 +11,19 @@ import (
 )
 
 func TestCommand_noCommandArg(t *testing.T) {
-	StubCommandLineArgs(nil)
+	StubCommandLineArgs()
 	err := command()
 	assert.Equal(t, "Unknown command: \n", err.Error())
 }
 
 func TestCommand_badCommandArg(t *testing.T) {
-	StubCommandLineArgs([]string{"doesnotexist"})
+	StubCommandLineArgs("doesnotexist")
 	err := command()
 	assert.Equal(t, "Unknown command: doesnotexist\n", err.Error())
 }
 
 func TestCommand_link_noArgs(t *testing.T) {
-	StubCommandLineArgs([]string{"link"})
+	StubCommandLineArgs("link")
 
 	appDir, _ := homedir.Expand("~/my-test-puma-dev-application")
 
@@ -44,7 +44,7 @@ func TestCommand_link_noArgs(t *testing.T) {
 func TestCommand_link_withNameOverride(t *testing.T) {
 	tmpCwd := "/tmp/puma-dev-example-command-link-noargs"
 
-	StubCommandLineArgs([]string{"link", "-n", "anothername", tmpCwd})
+	StubCommandLineArgs("link", "-n", "anothername", tmpCwd)
 
 	WithWorkingDirectory(tmpCwd, func() {
 		actual := WithStdoutCaptured(func() {
@@ -60,7 +60,7 @@ func TestCommand_link_withNameOverride(t *testing.T) {
 }
 
 func TestCommand_link_invalidDirectory(t *testing.T) {
-	StubCommandLineArgs([]string{"link", "/this/path/does/not/exist"})
+	StubCommandLineArgs("link", "/this/path/does/not/exist")
 
 	err := command()
 
@@ -76,7 +76,7 @@ func TestCommand_link_reassignExistingApp(t *testing.T) {
 	defer RemoveDirectoryOrFail(t, appDir2)
 	defer RemoveAppSymlinkOrFail(t, appAlias)
 
-	StubCommandLineArgs([]string{"link", "-n", appAlias, appDir1})
+	StubCommandLineArgs("link", "-n", appAlias, appDir1)
 	actual1 := WithStdoutCaptured(func() {
 		if err := command(); err != nil {
 			assert.Fail(t, err.Error())
@@ -85,7 +85,7 @@ func TestCommand_link_reassignExistingApp(t *testing.T) {
 
 	assert.Equal(t, fmt.Sprintf("+ App '%s' created, linked to '%s'\n", appAlias, appDir1), actual1)
 
-	StubCommandLineArgs([]string{"link", "-n", appAlias, appDir2})
+	StubCommandLineArgs("link", "-n", appAlias, appDir2)
 	actual2 := WithStdoutCaptured(func() {
 		if err := command(); err != nil {
 			assert.Fail(t, err.Error())

--- a/cmd/puma-dev/main.go
+++ b/cmd/puma-dev/main.go
@@ -7,19 +7,30 @@ import (
 	"runtime"
 )
 
-var fVersion = flag.Bool("V", false, "display version info")
-var Version = "devel"
+var (
+	EarlyExitClean = CommandResult{0, true}
+	EarlyExitError = CommandResult{1, true}
+	Continue       = CommandResult{-1, false}
+
+	fVersion = flag.Bool("V", false, "display version info")
+	Version  = "devel"
+)
+
+type CommandResult struct {
+	exitStatusCode int
+	shouldExit     bool
+}
 
 func allCheck() {
-	if status, shouldExit := execWithExitStatus(); shouldExit {
-		os.Exit(status)
+	if result := execWithExitStatus(); result.shouldExit {
+		os.Exit(result.exitStatusCode)
 	}
 }
 
-func execWithExitStatus() (int, bool) {
+func execWithExitStatus() CommandResult {
 	if *fVersion {
 		fmt.Printf("Version: %s (%s)\n", Version, runtime.Version())
-		return 0, true
+		return EarlyExitClean
 	}
 
 	if flag.NArg() > 0 {
@@ -27,13 +38,13 @@ func execWithExitStatus() (int, bool) {
 
 		if err != nil {
 			fmt.Printf("Error: %s\n", err)
-			return 1, true
+			return EarlyExitError
 		}
 
-		return 0, true
+		return EarlyExitClean
 	}
 
-	return -1, false
+	return Continue
 }
 
 func init() {

--- a/cmd/puma-dev/main.go
+++ b/cmd/puma-dev/main.go
@@ -14,7 +14,7 @@ var Version = "devel"
 func allCheck() {
 	if *fVersion {
 		fmt.Printf("Version: %s (%s)\n", Version, runtime.Version())
-		os.Exit(1)
+		os.Exit(0)
 	}
 
 	if flag.NArg() > 0 {

--- a/cmd/puma-dev/main.go
+++ b/cmd/puma-dev/main.go
@@ -12,21 +12,29 @@ var fVersion = flag.Bool("V", false, "display version info")
 var Version = "devel"
 
 func allCheck() {
+	if status := execWithStatus(); status >= 0 {
+		os.Exit(0)
+	}
+}
+
+func execWithStatus() int {
 	if *fVersion {
 		fmt.Printf("Version: %s (%s)\n", Version, runtime.Version())
-		os.Exit(0)
+		return 0
 	}
 
 	if flag.NArg() > 0 {
 		err := command()
+
 		if err != nil {
 			fmt.Printf("Error: %s\n", err)
-			os.Exit(1)
+			return 1
 		}
 
-		os.Exit(0)
-		return
+		return 0
 	}
+
+	return -1
 }
 
 func init() {

--- a/cmd/puma-dev/main.go
+++ b/cmd/puma-dev/main.go
@@ -8,19 +8,18 @@ import (
 )
 
 var fVersion = flag.Bool("V", false, "display version info")
-
 var Version = "devel"
 
 func allCheck() {
-	if status := execWithStatus(); status >= 0 {
-		os.Exit(0)
+	if status, shouldExit := execWithExitStatus(); shouldExit {
+		os.Exit(status)
 	}
 }
 
-func execWithStatus() int {
+func execWithExitStatus() (int, bool) {
 	if *fVersion {
 		fmt.Printf("Version: %s (%s)\n", Version, runtime.Version())
-		return 0
+		return 0, true
 	}
 
 	if flag.NArg() > 0 {
@@ -28,13 +27,13 @@ func execWithStatus() int {
 
 		if err != nil {
 			fmt.Printf("Error: %s\n", err)
-			return 1
+			return 1, true
 		}
 
-		return 0
+		return 0, true
 	}
 
-	return -1
+	return -1, false
 }
 
 func init() {

--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -15,7 +15,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestMain_execWithExitStatus_versionFlag(t *testing.T) {
-	StubCommandLineArgs([]string{"-V"})
+	StubCommandLineArgs("-V")
 	assert.True(t, *fVersion)
 
 	execStdOut := WithStdoutCaptured(func() {
@@ -28,7 +28,7 @@ func TestMain_execWithExitStatus_versionFlag(t *testing.T) {
 }
 
 func TestMain_execWithExitStatus_noFlag(t *testing.T) {
-	StubCommandLineArgs(nil)
+	StubCommandLineArgs()
 	assert.False(t, *fVersion)
 
 	execStdOut := WithStdoutCaptured(func() {
@@ -41,7 +41,7 @@ func TestMain_execWithExitStatus_noFlag(t *testing.T) {
 
 func TestMain_allCheck_versionFlag(t *testing.T) {
 	if os.Getenv("GO_TEST_SUBPROCESS") == "1" {
-		StubCommandLineArgs([]string{"-V"})
+		StubCommandLineArgs("-V")
 		allCheck()
 
 		return
@@ -59,7 +59,7 @@ func TestMain_allCheck_versionFlag(t *testing.T) {
 
 func TestMain_allCheck_badArg(t *testing.T) {
 	if os.Getenv("GO_TEST_SUBPROCESS") == "1" {
-		StubCommandLineArgs([]string{"-badarg"})
+		StubCommandLineArgs("-badarg")
 		allCheck()
 
 		return

--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestMain(m *testing.M) {
+	EnsurePumaDevDirectory()
+	os.Exit(m.Run())
+}
+
 func TestMain_execWithExitStatus_versionFlag(t *testing.T) {
 	StubCommandLineArgs([]string{"-V"})
 	assert.True(t, *fVersion)

--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"os"
 	"os/exec"
 	"testing"
@@ -10,18 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//
-// func FlagResetForTesting() {
-// 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
-// 	flag.CommandLine.Usage = flag.Usage()
-// }
-
 func TestMain_execWithExitStatus_versionFlag(t *testing.T) {
 	StubCommandLineArgs([]string{"-V"})
-	if err := flag.Set("V", "true"); err != nil {
-		panic(err)
-	}
-
 	assert.True(t, *fVersion)
 
 	execStdOut := WithStdoutCaptured(func() {
@@ -35,10 +24,6 @@ func TestMain_execWithExitStatus_versionFlag(t *testing.T) {
 
 func TestMain_execWithExitStatus_noFlag(t *testing.T) {
 	StubCommandLineArgs(nil)
-	if err := flag.Set("V", "false"); err != nil {
-		panic(err)
-	}
-
 	assert.False(t, *fVersion)
 
 	execStdOut := WithStdoutCaptured(func() {

--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -1,12 +1,39 @@
 package main
 
 import (
+	"flag"
 	"os"
 	"os/exec"
 	"testing"
 
 	. "github.com/puma/puma-dev/dev/devtest"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestMain_execWithExitStatus_versionFlag(t *testing.T) {
+	flag.Set("V", "true")
+	assert.True(t, *fVersion)
+
+	execStdOut := WithStdoutCaptured(func() {
+		status, shouldExit := execWithExitStatus()
+		assert.Equal(t, 0, status)
+		assert.Equal(t, true, shouldExit)
+	})
+
+	assert.Regexp(t, "^Version: devel \\(go[0-9.]+\\)\\n$", execStdOut)
+}
+
+func TestMain_execWithExitStatus_noFlag(t *testing.T) {
+	flag.Set("V", "false")
+	assert.False(t, *fVersion)
+
+	execStdOut := WithStdoutCaptured(func() {
+		_, shouldExit := execWithExitStatus()
+		assert.Equal(t, false, shouldExit)
+	})
+
+	assert.Equal(t, "", execStdOut)
+}
 
 func TestMain_allCheck_versionFlag(t *testing.T) {
 	if os.Getenv("GO_TEST_SUBPROCESS") == "1" {

--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -46,8 +46,8 @@ func TestMain_allCheck_versionFlag(t *testing.T) {
 	cmd.Env = append(os.Environ(), "GO_TEST_SUBPROCESS=1")
 	err := cmd.Run()
 
-	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
-		t.Fatalf("`puma-dev -V` had exit status %v, wanted exit status 0", err)
+	if exit, ok := err.(*exec.ExitError); ok && !exit.Success() {
+		t.Fatalf("`puma-dev -V` errored with exit %v)", exit)
 	}
 }
 
@@ -59,11 +59,11 @@ func TestMain_allCheck_badArg(t *testing.T) {
 		return
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestMain_allCheck_versionFlagWithArgs")
+	cmd := exec.Command(os.Args[0], "-test.run=TestMain_allCheck_badArg")
 	cmd.Env = append(os.Environ(), "GO_TEST_SUBPROCESS=1")
 	err := cmd.Run()
 
-	if e, ok := err.(*exec.ExitError); ok && e.Success() {
-		t.Fatalf("`puma-dev -badarg` had exit status %v, wanted exit status 1", err)
+	if exit, ok := err.(*exec.ExitError); !ok || exit.Success() {
+		t.Fatalf("`puma-dev -badarg` did not error (err: %v)", err)
 	}
 }

--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -19,7 +19,7 @@ func TestMain_execWithExitStatus_versionFlag(t *testing.T) {
 		assert.Equal(t, true, shouldExit)
 	})
 
-	assert.Regexp(t, "^Version: devel \\(go[0-9.]+\\)\\n$", execStdOut)
+	assert.Regexp(t, "^Version: devel \\(.+\\)\\n$", execStdOut)
 }
 
 func TestMain_execWithExitStatus_noFlag(t *testing.T) {

--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -21,13 +21,13 @@ func TestMain_allCheck_versionFlag(t *testing.T) {
 	err := cmd.Run()
 
 	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
-		t.Fatalf("process ran with err %v, want exit status 0", err)
+		t.Fatalf("`puma-dev -V` had exit status %v, wanted exit status 0", err)
 	}
 }
 
 func TestMain_allCheck_badArg(t *testing.T) {
 	if os.Getenv("GO_TEST_SUBPROCESS") == "1" {
-		StubFlagArgs([]string{"bad-argument-that-does-not-exist"})
+		StubFlagArgs([]string{"-badarg"})
 		allCheck()
 
 		return
@@ -38,6 +38,6 @@ func TestMain_allCheck_badArg(t *testing.T) {
 	err := cmd.Run()
 
 	if e, ok := err.(*exec.ExitError); ok && e.Success() {
-		t.Fatalf("process ran with err %v, want exit status 1", err)
+		t.Fatalf("`puma-dev -badarg` had exit status %v, wanted exit status 1", err)
 	}
 }

--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -10,8 +10,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+//
+// func FlagResetForTesting() {
+// 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+// 	flag.CommandLine.Usage = flag.Usage()
+// }
+
 func TestMain_execWithExitStatus_versionFlag(t *testing.T) {
-	flag.Set("V", "true")
+	StubCommandLineArgs([]string{"-V"})
+	if err := flag.Set("V", "true"); err != nil {
+		panic(err)
+	}
+
 	assert.True(t, *fVersion)
 
 	execStdOut := WithStdoutCaptured(func() {
@@ -24,7 +34,11 @@ func TestMain_execWithExitStatus_versionFlag(t *testing.T) {
 }
 
 func TestMain_execWithExitStatus_noFlag(t *testing.T) {
-	flag.Set("V", "false")
+	StubCommandLineArgs(nil)
+	if err := flag.Set("V", "false"); err != nil {
+		panic(err)
+	}
+
 	assert.False(t, *fVersion)
 
 	execStdOut := WithStdoutCaptured(func() {
@@ -37,7 +51,7 @@ func TestMain_execWithExitStatus_noFlag(t *testing.T) {
 
 func TestMain_allCheck_versionFlag(t *testing.T) {
 	if os.Getenv("GO_TEST_SUBPROCESS") == "1" {
-		StubFlagArgs([]string{"-V"})
+		StubCommandLineArgs([]string{"-V"})
 		allCheck()
 
 		return
@@ -54,7 +68,7 @@ func TestMain_allCheck_versionFlag(t *testing.T) {
 
 func TestMain_allCheck_badArg(t *testing.T) {
 	if os.Getenv("GO_TEST_SUBPROCESS") == "1" {
-		StubFlagArgs([]string{"-badarg"})
+		StubCommandLineArgs([]string{"-badarg"})
 		allCheck()
 
 		return

--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -46,9 +46,10 @@ func TestMain_allCheck_versionFlag(t *testing.T) {
 	cmd.Env = append(os.Environ(), "GO_TEST_SUBPROCESS=1")
 	err := cmd.Run()
 
-	if exit, ok := err.(*exec.ExitError); ok && !exit.Success() {
-		t.Fatalf("`puma-dev -V` errored with exit %v)", exit)
-	}
+	exit, ok := err.(*exec.ExitError)
+
+	assert.False(t, ok)
+	assert.Nil(t, exit)
 }
 
 func TestMain_allCheck_badArg(t *testing.T) {
@@ -63,7 +64,8 @@ func TestMain_allCheck_badArg(t *testing.T) {
 	cmd.Env = append(os.Environ(), "GO_TEST_SUBPROCESS=1")
 	err := cmd.Run()
 
-	if exit, ok := err.(*exec.ExitError); !ok || exit.Success() {
-		t.Fatalf("`puma-dev -badarg` did not error (err: %v)", err)
-	}
+	exit, ok := err.(*exec.ExitError)
+
+	assert.True(t, ok)
+	assert.False(t, exit.Success())
 }

--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -63,10 +63,7 @@ func TestMain_allCheck_versionFlag(t *testing.T) {
 	cmd.Env = append(os.Environ(), "GO_TEST_SUBPROCESS=1")
 	err := cmd.Run()
 
-	exit, ok := err.(*exec.ExitError)
-
-	assert.False(t, ok)
-	assert.Nil(t, exit)
+	assert.Nil(t, err)
 }
 
 func TestMain_allCheck_badArg(t *testing.T) {

--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -39,6 +39,18 @@ func TestMain_execWithExitStatus_noFlag(t *testing.T) {
 	assert.Equal(t, "", execStdOut)
 }
 
+func TestMain_execWithExitStatus_commandArgs(t *testing.T) {
+	StubCommandLineArgs("nosoupforyou")
+
+	execStdOut := WithStdoutCaptured(func() {
+		status, shouldExit := execWithExitStatus()
+		assert.Equal(t, 1, status)
+		assert.Equal(t, true, shouldExit)
+	})
+
+	assert.Equal(t, "Error: Unknown command: nosoupforyou\n\n", execStdOut)
+}
+
 func TestMain_allCheck_versionFlag(t *testing.T) {
 	if os.Getenv("GO_TEST_SUBPROCESS") == "1" {
 		StubCommandLineArgs("-V")

--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	. "github.com/puma/puma-dev/dev/devtest"
+)
+
+func TestMain_allCheck_versionFlag(t *testing.T) {
+	if os.Getenv("GO_TEST_SUBPROCESS") == "1" {
+		StubFlagArgs([]string{"-V"})
+		allCheck()
+
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestMain_allCheck_versionFlag")
+	cmd.Env = append(os.Environ(), "GO_TEST_SUBPROCESS=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		t.Fatalf("process ran with err %v, want exit status 0", err)
+	}
+}
+
+func TestMain_allCheck_badArg(t *testing.T) {
+	if os.Getenv("GO_TEST_SUBPROCESS") == "1" {
+		StubFlagArgs([]string{"bad-argument-that-does-not-exist"})
+		allCheck()
+
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestMain_allCheck_versionFlagWithArgs")
+	cmd.Env = append(os.Environ(), "GO_TEST_SUBPROCESS=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && e.Success() {
+		t.Fatalf("process ran with err %v, want exit status 1", err)
+	}
+}

--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -19,9 +19,9 @@ func TestMain_execWithExitStatus_versionFlag(t *testing.T) {
 	assert.True(t, *fVersion)
 
 	execStdOut := WithStdoutCaptured(func() {
-		status, shouldExit := execWithExitStatus()
-		assert.Equal(t, 0, status)
-		assert.Equal(t, true, shouldExit)
+		result := execWithExitStatus()
+		assert.Equal(t, 0, result.exitStatusCode)
+		assert.Equal(t, true, result.shouldExit)
 	})
 
 	assert.Regexp(t, "^Version: devel \\(.+\\)\\n$", execStdOut)
@@ -32,8 +32,8 @@ func TestMain_execWithExitStatus_noFlag(t *testing.T) {
 	assert.False(t, *fVersion)
 
 	execStdOut := WithStdoutCaptured(func() {
-		_, shouldExit := execWithExitStatus()
-		assert.Equal(t, false, shouldExit)
+		result := execWithExitStatus()
+		assert.Equal(t, false, result.shouldExit)
 	})
 
 	assert.Equal(t, "", execStdOut)
@@ -43,9 +43,9 @@ func TestMain_execWithExitStatus_commandArgs(t *testing.T) {
 	StubCommandLineArgs("nosoupforyou")
 
 	execStdOut := WithStdoutCaptured(func() {
-		status, shouldExit := execWithExitStatus()
-		assert.Equal(t, 1, status)
-		assert.Equal(t, true, shouldExit)
+		result := execWithExitStatus()
+		assert.Equal(t, 1, result.exitStatusCode)
+		assert.Equal(t, true, result.shouldExit)
 	})
 
 	assert.Equal(t, "Error: Unknown command: nosoupforyou\n\n", execStdOut)

--- a/dev/devtest/testutils.go
+++ b/dev/devtest/testutils.go
@@ -16,11 +16,23 @@ import (
 )
 
 var (
+<<<<<<< HEAD
 	appSymlinkHome = "~/.puma-dev"
 	_, b, _, _     = runtime.Caller(0)
 	ProjectRoot    = filepath.Join(filepath.Dir(b), "..", "..")
 	stubbedArgs    = make(map[string]int)
+=======
+	DebugLoggingEnabled = os.Getenv("DEBUG_LOG") == "1"
+	appSymlinkHome      = "~/.puma-dev"
+	StubbedArgs         = make(map[string]int)
+>>>>>>> aed9608... ok, proceed with the reset-to-default-if-stubbed strategy.
 )
+
+func LogDebugf(msg string, vars ...interface{}) {
+	if DebugLoggingEnabled {
+		log.Printf(strings.Join([]string{"[DEBUG]", msg}, " "), vars...)
+	}
+}
 
 /*
 	StubCommandLineArgs overrides command arguments to allow flag-based branches
@@ -31,15 +43,18 @@ var (
 */
 func StubCommandLineArgs(args []string) {
 	for _, arg := range args {
-		stubbedArgs[arg] += 1
+		StubbedArgs[arg] += 1
 	}
 
-	for arg := range stubbedArgs {
+	for arg := range StubbedArgs {
 		stubbedFlagName := strings.Replace(arg, "-", "", -1)
 
 		if fl := flag.Lookup(stubbedFlagName); fl != nil {
+
+			oldValue := fl.Value.String()
+
 			if err := flag.Set(fl.Name, fl.DefValue); err == nil {
-				log.Printf("reset %+v", fl)
+				LogDebugf("reset flag %s to %s (was %s)", fl.Name, fl.Value.String(), oldValue)
 			}
 		}
 	}

--- a/dev/devtest/testutils.go
+++ b/dev/devtest/testutils.go
@@ -18,9 +18,9 @@ import (
 var (
 	appSymlinkHome      = "~/.puma-dev"
 	DebugLoggingEnabled = os.Getenv("DEBUG_LOG") == "1"
+	StubbedArgs         = make(map[string]int)
 	_, b, _, _          = runtime.Caller(0)
 	ProjectRoot         = filepath.Join(filepath.Dir(b), "..", "..")
-	StubbedArgs         = make(map[string]int)
 )
 
 func LogDebugf(msg string, vars ...interface{}) {

--- a/dev/devtest/testutils.go
+++ b/dev/devtest/testutils.go
@@ -19,19 +19,19 @@ var (
 	ProjectRoot    = filepath.Join(filepath.Dir(b), "..", "..")
 )
 
-func resetAllFlagValuesToDefault() {
+// StubCommandLineArgs overrides command arguments to allow flag-based branches to execute. It does not
+// modify os.Args[0] so it can be used for subprocess tests. It also resets all defined flags to their
+// default values, as flag.Parse() will not reset non-existent boolean flags if they have been stubbed
+// in other tests.
+func StubCommandLineArgs(args []string) {
+	os.Args = append([]string{os.Args[0]}, args...)
+
 	flag.VisitAll(func(fl *flag.Flag) {
 		if err := flag.Set(fl.Name, fl.DefValue); err != nil {
 			panic(err)
 		}
 	})
-}
 
-// StubCommandLineArgs overrides command arguments to allow flag-based branches to execute.
-// Note that it does NOT modify os.Args[0] so it can be used for subprocess tests.
-func StubCommandLineArgs(args []string) {
-	os.Args = append([]string{os.Args[0]}, args...)
-	resetAllFlagValuesToDefault()
 	flag.Parse()
 }
 

--- a/dev/devtest/testutils.go
+++ b/dev/devtest/testutils.go
@@ -19,11 +19,10 @@ var (
 	ProjectRoot    = filepath.Join(filepath.Dir(b), "..", "..")
 )
 
-// StubFlagArgs overrides command arguments to pretend as if puma-dev was executed at the commandline.
-// ex: StubArgFlags([]string{"-n", "myapp", "path/to/app"}) ->
-//   $ puma-dev -n myapp path/to/app
+// StubFlagArgs overrides command arguments to allow flag-based branches to execute.
+// Note that it does NOT modify os.Args[0] so it can be used for subprocess tests.
 func StubFlagArgs(args []string) {
-	os.Args = append([]string{"puma-dev"}, args...)
+	os.Args = append([]string{os.Args[0]}, args...)
 	flag.Parse()
 }
 

--- a/dev/devtest/testutils.go
+++ b/dev/devtest/testutils.go
@@ -19,9 +19,9 @@ var (
 	ProjectRoot    = filepath.Join(filepath.Dir(b), "..", "..")
 )
 
-// StubFlagArgs overrides command arguments to allow flag-based branches to execute.
+// StubCommandLineArgs overrides command arguments to allow flag-based branches to execute.
 // Note that it does NOT modify os.Args[0] so it can be used for subprocess tests.
-func StubFlagArgs(args []string) {
+func StubCommandLineArgs(args []string) {
 	os.Args = append([]string{os.Args[0]}, args...)
 	flag.Parse()
 }

--- a/dev/devtest/testutils.go
+++ b/dev/devtest/testutils.go
@@ -19,10 +19,19 @@ var (
 	ProjectRoot    = filepath.Join(filepath.Dir(b), "..", "..")
 )
 
+func resetAllFlagValuesToDefault() {
+	flag.VisitAll(func(fl *flag.Flag) {
+		if err := flag.Set(fl.Name, fl.DefValue); err != nil {
+			panic(err)
+		}
+	})
+}
+
 // StubCommandLineArgs overrides command arguments to allow flag-based branches to execute.
 // Note that it does NOT modify os.Args[0] so it can be used for subprocess tests.
 func StubCommandLineArgs(args []string) {
 	os.Args = append([]string{os.Args[0]}, args...)
+	resetAllFlagValuesToDefault()
 	flag.Parse()
 }
 

--- a/dev/devtest/testutils.go
+++ b/dev/devtest/testutils.go
@@ -16,16 +16,11 @@ import (
 )
 
 var (
-<<<<<<< HEAD
-	appSymlinkHome = "~/.puma-dev"
-	_, b, _, _     = runtime.Caller(0)
-	ProjectRoot    = filepath.Join(filepath.Dir(b), "..", "..")
-	stubbedArgs    = make(map[string]int)
-=======
-	DebugLoggingEnabled = os.Getenv("DEBUG_LOG") == "1"
 	appSymlinkHome      = "~/.puma-dev"
+	DebugLoggingEnabled = os.Getenv("DEBUG_LOG") == "1"
+	_, b, _, _          = runtime.Caller(0)
+	ProjectRoot         = filepath.Join(filepath.Dir(b), "..", "..")
 	StubbedArgs         = make(map[string]int)
->>>>>>> aed9608... ok, proceed with the reset-to-default-if-stubbed strategy.
 )
 
 func LogDebugf(msg string, vars ...interface{}) {

--- a/dev/devtest/testutils.go
+++ b/dev/devtest/testutils.go
@@ -41,7 +41,7 @@ func LogDebugf(msg string, vars ...interface{}) {
 	`flag.Parse()` will not reset non-existent boolean flags if they have been
 	stubbed in other tests.
 */
-func StubCommandLineArgs(args []string) {
+func StubCommandLineArgs(args ...string) {
 	for _, arg := range args {
 		StubbedArgs[arg] += 1
 	}

--- a/dev/devtest/testutils.go
+++ b/dev/devtest/testutils.go
@@ -19,10 +19,13 @@ var (
 	ProjectRoot    = filepath.Join(filepath.Dir(b), "..", "..")
 )
 
-// StubCommandLineArgs overrides command arguments to allow flag-based branches to execute. It does not
-// modify os.Args[0] so it can be used for subprocess tests. It also resets all defined flags to their
-// default values, as flag.Parse() will not reset non-existent boolean flags if they have been stubbed
-// in other tests.
+/*
+	StubCommandLineArgs overrides command arguments to allow flag-based branches
+	to execute. It does not modify os.Args[0] so it can be used for subprocess
+	tests. It also resets all defined flags to their default values, as
+	`flag.Parse()` will not reset non-existent boolean flags if they have been
+	stubbed in other tests.
+*/
 func StubCommandLineArgs(args []string) {
 	os.Args = append([]string{os.Args[0]}, args...)
 
@@ -52,7 +55,8 @@ func EnsurePumaDevDirectory() {
 	}
 }
 
-// WithStdoutCaptured executes the passed function and returns a string containing the stdout of the executed function.
+// WithStdoutCaptured executes the passed function and returns a string
+// containing the stdout of the executed function.
 func WithStdoutCaptured(f func()) string {
 	osStdout := os.Stdout
 	r, w, err := os.Pipe()
@@ -91,7 +95,8 @@ func RemoveDirectoryOrFail(t *testing.T, path string) {
 	}
 }
 
-// MakeDirectoryOrFail makes a directory or fails the test, returning the path of the directory that was created.
+// MakeDirectoryOrFail makes a directory or fails the test, returning the path
+// of the directory that was created.
 func MakeDirectoryOrFail(t *testing.T, path string) string {
 	if err := os.Mkdir(path, 0755); err != nil {
 		assert.Fail(t, err.Error())

--- a/dev/devtest/testutils_test.go
+++ b/dev/devtest/testutils_test.go
@@ -1,0 +1,21 @@
+package devtest
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var fTribe = flag.Bool("cankickit", false, "Can I kick it?")
+
+func TestStubCommandLineArgs(t *testing.T) {
+	StubCommandLineArgs("-cankickit")
+	assert.True(t, *fTribe)
+	StubCommandLineArgs()
+	assert.False(t, *fTribe)
+	StubCommandLineArgs("-cankickit")
+	assert.True(t, *fTribe)
+	StubCommandLineArgs()
+	assert.False(t, *fTribe)
+}

--- a/dev/devtest/testutils_test.go
+++ b/dev/devtest/testutils_test.go
@@ -10,7 +10,13 @@ import (
 var fTribe = flag.Bool("cankickit", false, "Can I kick it?")
 
 func TestStubCommandLineArgs(t *testing.T) {
+	StubCommandLineArgs()
+	assert.False(t, *fTribe)
 	StubCommandLineArgs("-cankickit")
+	assert.True(t, *fTribe)
+	StubCommandLineArgs("-cankickit=false")
+	assert.False(t, *fTribe)
+	StubCommandLineArgs("-cankickit=true")
 	assert.True(t, *fTribe)
 	StubCommandLineArgs()
 	assert.False(t, *fTribe)


### PR DESCRIPTION
This PR fulfills the intent expressed in https://github.com/puma/puma-dev/pull/211 and adds test coverage.

Woof. This sent me down a rabbithole. Open to -- and will warmly receive -- feedback! It's continuinally amazing that intending to make a single character change can ~require~ inspire a ~100 line test file. 😂 

## Changes
- [x] Write a failing test case to ensure `puma-dev -V` exits with status code 0.
  - This "subprocess" testing approach looks dirty, but is an accepted pattern within the golang community. https://talks.golang.org/2014/testing.slide#23
  - Subprocess tests don't correctly report coverage however. Which lead to a small red-green-refactor.
- [x] Merge @bzf's change to exit with status code 0. Ensure said test passes.
- [x] Refactor out status code calculation into a secondary method to allow for better testing. Previous tests ensure we don't break anything.
- [x] Test refactored method, now that we're able to look at stdout in isolation.
- [x] Improvements / clarifications to `testutils.go` to ensure that flags are reset correctly.
  - ^^ This one is what made things so tricky. See below.
- [x] As `testutils` has now gotten a bit complicated, add tests for testutils.
- [x] Add `make coverage` which will open a coverage report in a browser. Eventually, would love to integrate into CI, but, again, #babysteps.

### Let's talk about `os.Args` and `flag`

`puma-dev` mixes flags (e.g. `puma-dev -V`) and commandline arguments (e.g. `puma-dev link`). In order to test these branches, I'm abusing `os.Args` in tests and then subsequently calling `flag.Parse()` again. This works beautifully if you're providing all the flags, all the time. But if you simulate `puma-dev -V` and then simulate `puma-dev`, the old value of "true" is still stored in the `fVersion flag.Flag`. You can't rely on the absence of a flag on the commandline to reset it. This makes sense given the original intent of `flag`. 

We can't just reset *all* the flags, because then the flags that are passed in for testing (e.g. `-cover`) will be reset as well. It felt super brittle to enumerate all the puma-dev specific flags in a test file and reset them, so, instead, I'm saving which commandline args that map to flags (i.e. start with `-`) have been stubbed, and then restoring them to their default values. I don't love it, but it gets the job done. I've added a `testutils_test.go` to verify the intended behavior.