### PR TITLE
exercise file watch (for tmp/restart.txt support) in tests, bump fsnotify/fsevents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/pkg/
 /puma-dev
 /puma-dev-*zip
 /puma-dev-*tar.gz
+/tmp

--- a/dev/devtest/testutils.go
+++ b/dev/devtest/testutils.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/puma/puma-dev/homedir"
@@ -14,6 +15,8 @@ import (
 
 var (
 	appSymlinkHome = "~/.puma-dev"
+	_, b, _, _     = runtime.Caller(0)
+	ProjectRoot    = filepath.Join(filepath.Dir(b), "..", "..")
 )
 
 // StubFlagArgs overrides command arguments to pretend as if puma-dev was executed at the commandline.
@@ -129,4 +132,13 @@ func RemoveAppSymlinkOrFail(t *testing.T, name string) {
 	if err := os.Remove(path); err != nil {
 		panic(err)
 	}
+}
+
+// FileExists returns true if a regular file exists at the given path.
+func FileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
-	github.com/fsnotify/fsevents v0.1.0
+	github.com/fsnotify/fsevents v0.1.1
 	github.com/hashicorp/golang-lru v0.0.0-20160207214719-a0d98a5f2880
 	github.com/kardianos/osext v0.0.0-20151222153229-29ae4ffbc9a6
 	github.com/miekg/dns v0.0.0-20160726032027-db96a2b759cd

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac/go.mod h1:8rLXio+Wji
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fsnotify/fsevents v0.1.0 h1:qeALFWR0ZE27D78Zq8mYxCF/5YrioLzrddiDz5pbR7c=
-github.com/fsnotify/fsevents v0.1.0/go.mod h1:+d+hS27T6k5J8CRaPLKFgwKYcpS7GwW3Ule9+SC2ZRc=
+github.com/fsnotify/fsevents v0.1.1 h1:/125uxJvvoSDDBPen6yUZbil8J9ydKZnnl3TWWmvnkw=
+github.com/fsnotify/fsevents v0.1.1/go.mod h1:+d+hS27T6k5J8CRaPLKFgwKYcpS7GwW3Ule9+SC2ZRc=
 github.com/hashicorp/golang-lru v0.0.0-20160207214719-a0d98a5f2880 h1:OaRuzt9oCKNui8cCskZijoKUwe+aCuuCwvx1ox8FNyw=
 github.com/hashicorp/golang-lru v0.0.0-20160207214719-a0d98a5f2880/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/kardianos/osext v0.0.0-20151222153229-29ae4ffbc9a6 h1:yZAE+xNuc/2gmWV+s5UAb43LYLZQiqyngl6IUCQGJg0=
@@ -16,8 +16,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
-github.com/stretchr/testify v1.1.4-0.20160221104443-1f4a1643a57e h1:4qDXrgFeUlF/B9aOKZBIn3JG+gF2YDlm9FOncBnm9k0=
-github.com/stretchr/testify v1.1.4-0.20160221104443-1f4a1643a57e/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/vektra/errors v0.0.0-20140903201135-c64d83aba85a h1:lUVfiMMY/te9icPKBqOKkBIMZNxSpM90dxokDeCcfBg=

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -34,6 +34,9 @@ func TestWatch_ExpectTouchSignalAfterModify(t *testing.T) {
 	touchFile(t, tmpRestartTxt)
 
 	watchTriggered := watchTmpFileWithTimeout(t, func() {
+		// HFS only has seconds resolution. We need to ensure that when we "touch"
+		// the file, we advance the modified time by at least one second.
+		time.Sleep(time.Second)
 		touchFile(t, tmpRestartTxt)
 	})
 
@@ -78,7 +81,7 @@ func watchTmpFileWithTimeout(t *testing.T, f func()) bool {
 
 	timeoutDone := make(chan struct{})
 	go func() {
-		time.Sleep(5 * time.Second)
+		time.Sleep(2 * time.Second)
 		timeoutDone <- Notice{}
 	}()
 

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -1,0 +1,95 @@
+package watch
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	devtest "github.com/puma/puma-dev/dev/devtest"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	tmpDir        = filepath.Join(devtest.ProjectRoot, "tmp")
+	tmpFilename   = "restart.txt"
+	tmpRestartTxt = filepath.Join(tmpDir, tmpFilename)
+)
+
+type Notice struct{}
+
+func TestWatch_ExpectTimeout(t *testing.T) {
+	defer createTmpDir(t)()
+	touchFile(t, tmpRestartTxt)
+
+	watchTriggered := watchTmpFileWithTimeout(t, func() {})
+
+	assert.False(t, watchTriggered)
+}
+
+func TestWatch_ExpectTouchSignalAfterModify(t *testing.T) {
+	defer createTmpDir(t)()
+	touchFile(t, tmpRestartTxt)
+
+	watchTriggered := watchTmpFileWithTimeout(t, func() {
+		touchFile(t, tmpRestartTxt)
+	})
+
+	assert.True(t, watchTriggered)
+}
+
+func createTmpDir(t *testing.T) func() {
+	devtest.MakeDirectoryOrFail(t, tmpDir)
+
+	return func() {
+		devtest.RemoveDirectoryOrFail(t, tmpDir)
+	}
+}
+
+func touchFile(t *testing.T, fullPath string) {
+	if err := exec.Command("sh", "-c", fmt.Sprintf("touch %s", fullPath)).Run(); err != nil {
+		assert.Fail(t, err.Error())
+	}
+}
+
+func watchTmpFileWithTimeout(t *testing.T, f func()) bool {
+	watchDone := make(chan struct{})
+	watchTriggered := false
+
+	if !devtest.FileExists(tmpRestartTxt) {
+		assert.Fail(t, fmt.Sprintf("%s does not exist", tmpRestartTxt))
+		return false
+	}
+
+	go func() {
+		err := Watch(tmpRestartTxt, watchDone, func() {
+			watchTriggered = true
+			watchDone <- Notice{}
+		})
+
+		if err != nil {
+			if _, ok := err.(*os.PathError); !ok {
+				panic(err)
+			}
+		}
+	}()
+
+	timeoutDone := make(chan struct{})
+	go func() {
+		time.Sleep(5 * time.Second)
+		timeoutDone <- Notice{}
+	}()
+
+	f()
+
+	for {
+		select {
+		case <-watchDone:
+			return watchTriggered
+		case <-timeoutDone:
+			return false
+		}
+	}
+}


### PR DESCRIPTION
This PR adds basic tests for the `watch` package. 

https://github.com/puma/puma-dev/issues/190 contains a number of users reporting that `puma-dev` doesn't respond to `touch tmp/readme.txt`. [@indirect's latest post](https://github.com/puma/puma-dev/issues/190#issuecomment-588623580) seems to indicate that it's a problem with the filesystem watch mechanism, potentially on macOS 10.15. I've been unable to replicate the issue on 10.14. 

Note: As of today, Travis doesn't have a [macOS 10.15 environment](https://travis-ci.community/t/macos-catalina-build-environment/5608/12). So, these tests don't _directly_ address the issues reported in #190. 😞

@evanphx @nateberkopec 