### PR TITLE
Linux CA certificate install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ sudo trust anchor --store ~/.puma-dev-ssl/cert.crt
 trust list --filter=ca-anchors | grep -i -C2 Puma-dev
 ```
 
+For Debian, Ubuntu etc, try this:
+
+```sh
+sudo mkdir -p /usr/local/share/ca-certificates
+sudo cp ~/.puma-dev-ssl/cert.pem /usr/local/share/ca-certificates/puma-dev-pem.crt
+sudo update-ca-certificates
+```
+
 ### Domains (.test or similar)
 
 In order for requests to the `.test` (or any other custom) domain to resolve, install the [dev-tld-resolver](https://github.com/puma/dev-tld-resolver), making sure to use `test` (or the custom TLD you want to use) when configuring TLDs.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ Puma-dev supports Linux but requires the following additional installation steps
 
 The puma-dev root CA is generated (in `~/.puma-dev-ssl/`), but you will need to install and trust this as a Certificate Authority by adding it to your operating system's certificate trust store, or by trusting it directly in your favored browser (as some browsers will not share the operating system's trust store).
 
+First, start puma-dev to generate a CA certificate into `~/.puma-dev-ssl/cert.pem`.
+
+For Arch Linux, Fedora and other distributions using [p11-kit](https://p11-glue.github.io/p11-glue/p11-kit.html), try this:
+
+```sh
+# convert from PEM to DER
+openssl x509 -in ~/.puma-dev-ssl/cert.pem -outform der -out ~/.puma-dev-ssl/cert.crt
+
+# store certificate as an anchor in the trust policy store
+sudo trust anchor --store ~/.puma-dev-ssl/cert.crt
+
+# verify
+trust list --filter=ca-anchors | grep -i -C2 Puma-dev
+```
+
 ### Domains (.test or similar)
 
 In order for requests to the `.test` (or any other custom) domain to resolve, install the [dev-tld-resolver](https://github.com/puma/dev-tld-resolver), making sure to use `test` (or the custom TLD you want to use) when configuring TLDs.


### PR DESCRIPTION
Add instructions to README.md for trusting puma-dev's CA certificate in linux.

Based on https://wiki.archlinux.org/index.php/User:Grawity/Adding_a_trusted_CA_certificate

* p11-kit style `trust anchor --store cert.crt` style verified on Arch linux. 
* Debian/Ubuntu etc style not verified, but it seems legit. 


---

Aside:

I made various attempts to keep the p11-kit version cleaner/simpler by avoiding writing the PEM→DER converted cert to disk, but:

* `trust` insists on DER format, so we can't just use the PEM file, and
* `trust anchor <(openssl -in cert.pem -outform der)` doesn't work because prior to `mmap`ing the file, `trust` calls `fstat` on the file handle and bails if it's not a real file; `strace` diff below.


![image](https://user-images.githubusercontent.com/15759/77046706-954f0f80-6a17-11ea-8539-436245a6b22a.png)