### PR TITLE
circleci support for go-1.13 on High Sierra, Mojave, and Catalina

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,104 @@
+version: 2.1
+
+commands:
+  gem_install_puma:
+    steps:
+      - run: ruby --version
+      - run: gem install puma
+
+  go_test:
+    steps:
+      - checkout
+      - run: go version
+      - run: go mod download
+      - run: go test -v -race -coverprofile=coverage.out -covermode=atomic -timeout=300s ./...
+
+  macos_check_version:
+    steps:
+      - run: sw_vers
+
+  macos_install_go_1_13:
+    steps:
+      - run:
+          name: install go v1.13
+          command: |
+            brew --version
+            cd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core
+            git fetch
+            git checkout b5c6a2435016eb4e96598c0ada5b1bad61775165 Formula/go.rb
+            brew install go
+            echo 'export PATH="/usr/local/opt/go/bin:$PATH"' >> $BASH_ENV
+            go version
+
+  macos_prepare_filesystem:
+    steps:
+      - run:
+          name: allow puma-dev to modify /etc/resolver
+          command: |
+            sudo mkdir -p /etc/resolver;
+            sudo chmod 0775 /etc/resolver;
+            sudo chown :staff /etc/resolver;
+
+  macos_set_ruby_2_5:
+    steps:
+      - run:
+          name: configure ruby-2.5
+          command: echo 'chruby ruby-2.5' >> $BASH_ENV
+
+jobs:
+  test_catalina:
+    macos:
+      xcode: 11.4.0
+    working_directory: /Users/distiller/go/src/puma/puma-dev
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      GO111MODULE: "on"
+      GOPATH: "/Users/distiller/go"
+    steps:
+      - macos_check_version
+      - macos_prepare_filesystem
+      - macos_install_go_1_13
+      - macos_set_ruby_2_5
+      - gem_install_puma
+      - go_test
+
+  test_mojave:
+    macos:
+      xcode: 11.1.0
+    working_directory: /Users/distiller/go/src/puma/puma-dev
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      GO111MODULE: "on"
+      GOPATH: "/Users/distiller/go"
+    steps:
+      - macos_check_version
+      - macos_prepare_filesystem
+      - macos_install_go_1_13
+      - macos_set_ruby_2_5
+      - gem_install_puma
+      - go_test
+
+  test_high_sierra:
+    macos:
+      xcode: 10.1.0
+    working_directory: /Users/distiller/go/src/puma/puma-dev
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      GO111MODULE: "on"
+      GOPATH: "/Users/distiller/go"
+    steps:
+      - macos_check_version
+      - macos_prepare_filesystem
+      - macos_install_go_1_13
+      - macos_set_ruby_2_5
+      - gem_install_puma
+      - go_test
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test_high_sierra
+      - test_mojave
+      - test_catalina
+


### PR DESCRIPTION
As TravisCI _still_ [doesn't support macOS Catalina](https://travis-ci.community/t/macos-catalina-build-environment/5608/12), I've been playing around with macOS builds on CircleCI on my fork. Just going to park the config file here, even if we don't hook it up yet or ever. 

