### PR TITLE
Ensure that Puma-dev CA is trusted in keychain (as expected) on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 /coverage.html
 
 .ruby-version
+.tool-versions
 
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -28,18 +28,24 @@ test:
 coverage: test
 	go tool cover -html=coverage.out -o coverage.html
 
-test-macos-interactive-certificate-install:
-	go test -coverprofile=coverage_osx.out -v -test.run=TestSetupOurCert_InteractiveCertificateInstall ./dev
+test-macos-interactive:
+	@echo "This will break your existing puma-dev setup. You'll need to run setup/install again. Cool? Cool."
+	@echo "Also, prepare to provide your system password several times."
+	@read -p "Press [return] to continue..."
+	go test ./... -v -test.run=DarwinInteractive -count=1
 
-test-macos-interactive-dev-setup-install: clean build
+test-macos-manual-setup-install: clean build
 	sudo launchctl unload "$$HOME/Library/LaunchAgents/io.puma.dev.plist"
 	rm -rf "$$HOME/Library/ApplicationSupport/io.puma.dev"
-	rm "$$HOME/Library/LaunchAgents/io.puma.dev.plist"
-	rm "$$HOME/Library/Logs/puma-dev.log"
+	rm -f "$$HOME/Library/LaunchAgents/io.puma.dev.plist"
+	rm -f "$$HOME/Library/Logs/puma-dev.log"
+
 	sudo ./puma-dev -d 'test:localhost:loc.al:puma' -setup
 	./puma-dev -d 'test:localhost:loc.al:puma' -install
+
 	test -f "$$HOME/Library/LaunchAgents/io.puma.dev.plist"
-	sleep 2
+	launchctl list io.puma.dev > /dev/null
 	test -f "$$HOME/Library/Logs/puma-dev.log"
+	test 'Hi Puma!' == "$$(curl -s https://rack-hi-puma.puma)" && echo "PASS"
 
 .PHONY: all release

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,13 @@ test-macos-interactive:
 	@echo "This will break your existing puma-dev setup. You'll need to run setup/install again. Cool? Cool."
 	@echo "Also, prepare to provide your system password several times."
 	@read -p "Press [return] to continue..."
+	rm -rf "$$HOME/Library/Application\ Support/io.puma.dev"
 	go test ./... -v -test.run=DarwinInteractive -count=1
+	rm -rf "$$HOME/Library/Application\ Support/io.puma.dev"
 
 test-macos-manual-setup-install: clean build
 	sudo launchctl unload "$$HOME/Library/LaunchAgents/io.puma.dev.plist"
-	rm -rf "$$HOME/Library/ApplicationSupport/io.puma.dev"
+	rm -rf "$$HOME/Library/Application\ Support/io.puma.dev"
 	rm -f "$$HOME/Library/LaunchAgents/io.puma.dev.plist"
 	rm -f "$$HOME/Library/Logs/puma-dev.log"
 

--- a/cmd/puma-dev/main_darwin.go
+++ b/cmd/puma-dev/main_darwin.go
@@ -36,6 +36,11 @@ var (
 	fUninstall = flag.Bool("uninstall", false, "Uninstall puma-dev as a user service")
 )
 
+const (
+	LaunchAgentDirPath = "~/Library/LaunchAgents"
+	LogFilePath        = "~/Library/Logs/puma-dev.log"
+)
+
 func main() {
 	flag.Parse()
 
@@ -54,7 +59,7 @@ func main() {
 	}
 
 	if *fUninstall {
-		dev.Uninstall(domains)
+		dev.Uninstall(LaunchAgentDirPath, domains)
 		return
 	}
 
@@ -62,9 +67,9 @@ func main() {
 		err := dev.InstallIntoSystem(&dev.InstallIntoSystemArgs{
 			ApplinkDirPath:     *fDir,
 			Domains:            *fDomains,
-			LaunchAgentDirPath: "~/Library/LaunchAgents",
+			LaunchAgentDirPath: LaunchAgentDirPath,
 			ListenPort:         *fInstallPort,
-			LogfilePath:        "~/Library/Logs/puma-dev.log",
+			LogfilePath:        LogFilePath,
 			Timeout:            (*fTimeout).String(),
 			TlsPort:            *fInstallTLS,
 		})

--- a/cmd/puma-dev/main_darwin.go
+++ b/cmd/puma-dev/main_darwin.go
@@ -59,7 +59,13 @@ func main() {
 	}
 
 	if *fUninstall {
-		dev.Uninstall(LaunchAgentDirPath, domains)
+		onlyDeleteNowUntrustedCertAndKeyInProductionPathFunc := dev.Uninstall(LaunchAgentDirPath, domains)
+		// FIXME: As part of running tests interactively on macOS, we can't delete .cert/.key
+		// generated as part of test runs. But, we don't want to leave untrusted .cert/.key's
+		// hanging around post-uninstall. So, we delete them as part of the main codepath but
+		// ignore this returned func during testing. Eventually, when the cert/key can be
+		// stored in the macOS keychain, we can rely on that to avoid this.
+		onlyDeleteNowUntrustedCertAndKeyInProductionPathFunc()
 		return
 	}
 

--- a/cmd/puma-dev/main_darwin_test.go
+++ b/cmd/puma-dev/main_darwin_test.go
@@ -2,10 +2,17 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
+	"io/ioutil"
 	"net"
+	"os"
+	"path/filepath"
+	"regexp"
 	"testing"
 
+	"github.com/puma/puma-dev/dev"
+	. "github.com/puma/puma-dev/dev/devtest"
 	"github.com/puma/puma-dev/homedir"
 
 	"github.com/stretchr/testify/assert"
@@ -52,4 +59,58 @@ func TestMainPumaDev_Darwin(t *testing.T) {
 		_, err = r.LookupIPAddr(ctx, "foo.tlddoesnotexist")
 		assert.Error(t, err)
 	})
+}
+
+func TestCertificateInstallAndTrustHTTPS_DarwinInteractive(t *testing.T) {
+	if m := flag.Lookup("test.run").Value.String(); m == "" || !regexp.MustCompile(m).MatchString(t.Name()) {
+		t.Skip("interactive test must be specified with -test.run=DarwinInteractive")
+	}
+
+	appLinkDir, _ := ioutil.TempDir("", ".puma-dev")
+
+	liveSupportPath := homedir.MustExpand(dev.SupportDir)
+	liveCertPath := filepath.Join(liveSupportPath, "cert.pem")
+	liveKeyPath := filepath.Join(liveSupportPath, "key.pem")
+
+	os.Remove(liveCertPath)
+	os.Remove(liveKeyPath)
+
+	assert.NoFileExists(t, liveCertPath)
+	assert.NoFileExists(t, liveKeyPath)
+
+	certInstallStdOut := WithStdoutCaptured(func() {
+		err := dev.SetupOurCert()
+		assert.Nil(t, err)
+
+		assert.FileExists(t, liveCertPath)
+		assert.FileExists(t, liveKeyPath)
+	})
+
+	defer func() {
+		err := dev.DeleteAllPumaDevCAFromDefaultKeychain()
+		assert.NoError(t, err)
+
+		os.Remove(appLinkDir)
+		os.Remove(liveCertPath)
+		os.Remove(liveKeyPath)
+	}()
+
+	assert.Regexp(t, "^\\* Adding certification to login keychain as trusted\\n", certInstallStdOut)
+	assert.Regexp(t, "! There is probably a dialog open that requires you to authenticate\\n", certInstallStdOut)
+	assert.Regexp(t, "\\* Certificates setup, ready for https operations!\\n$", certInstallStdOut)
+
+	defer linkAllTestApps(t, appLinkDir)()
+	serveErr := configureAndBootPumaDevServer(t, map[string]string{
+		"d":          "test:puma",
+		"dir":        appLinkDir,
+		"dns-port":   "55053",
+		"http-port":  "55080",
+		"https-port": "55443",
+	})
+
+	assert.NoError(t, serveErr)
+
+	tlsRequestURL := fmt.Sprintf("https://localhost:%d/", *fTLSPort)
+	tlsRequestHost := "hipuma"
+	assert.Equal(t, "Hi Puma!", getURLWithHost(t, tlsRequestURL, tlsRequestHost))
 }

--- a/dev/setup_darwin.go
+++ b/dev/setup_darwin.go
@@ -190,7 +190,7 @@ func InstallIntoSystem(config *InstallIntoSystemArgs) error {
 	}
 
 	// Unload a previous one if need be.
-	// nolint:errcheck noop looks like a failure
+	// nolint:errcheck
 	exec.Command("launchctl", "unload", plist).Run()
 
 	if err = exec.Command("launchctl", "load", plist).Run(); err != nil {
@@ -202,15 +202,23 @@ func InstallIntoSystem(config *InstallIntoSystemArgs) error {
 	return nil
 }
 
-func Uninstall(domains []string) {
-	plist := homedir.MustExpand("~/Library/LaunchAgents/io.puma.dev.plist")
+func Uninstall(launchAgentDirPath string, domains []string) {
+ 	// Default: ~/Library/LaunchAgents/
+	plistDir := homedir.MustExpand(launchAgentDirPath)
+	plist := filepath.Join(plistDir, "io.puma.dev.plist")
 
-	// Unload a previous one if need be.
+	// Remove puma-dev daemon
 	exec.Command("launchctl", "unload", plist).Run()
-
 	os.Remove(plist)
-
 	fmt.Printf("* Removed puma-dev from automatically running\n")
+
+	// Remove all `Puma-dev CA` certificate entries from macOS keychain
+	if err := DeleteAllPumaDevCAFromDefaultKeychain(); err != nil {
+		fmt.Printf("! Unable to remove all Puma-dev CA certs from macOS keychain: %s\n", err)
+	} else {
+		fmt.Printf("* Removed all Puma-dev CA certs from macOS keychain\n")
+		os.RemoveAll(SupportDir)
+	}
 
 	for _, d := range domains {
 		os.Remove(filepath.Join("/etc/resolver", d))

--- a/dev/setup_darwin.go
+++ b/dev/setup_darwin.go
@@ -203,7 +203,7 @@ func InstallIntoSystem(config *InstallIntoSystemArgs) error {
 }
 
 func Uninstall(launchAgentDirPath string, domains []string) {
- 	// Default: ~/Library/LaunchAgents/
+	// Default: ~/Library/LaunchAgents/
 	plistDir := homedir.MustExpand(launchAgentDirPath)
 	plist := filepath.Join(plistDir, "io.puma.dev.plist")
 
@@ -217,7 +217,7 @@ func Uninstall(launchAgentDirPath string, domains []string) {
 		fmt.Printf("! Unable to remove all Puma-dev CA certs from macOS keychain: %s\n", err)
 	} else {
 		fmt.Printf("* Removed all Puma-dev CA certs from macOS keychain\n")
-		os.RemoveAll(SupportDir)
+		os.RemoveAll(homedir.MustExpand(SupportDir))
 	}
 
 	for _, d := range domains {

--- a/dev/setup_darwin.go
+++ b/dev/setup_darwin.go
@@ -216,8 +216,9 @@ func Uninstall(launchAgentDirPath string, domains []string) {
 	if err := DeleteAllPumaDevCAFromDefaultKeychain(); err != nil {
 		fmt.Printf("! Unable to remove all Puma-dev CA certs from macOS keychain: %s\n", err)
 	} else {
-		fmt.Printf("* Removed all Puma-dev CA certs from macOS keychain\n")
-		os.RemoveAll(homedir.MustExpand(SupportDir))
+		expandedSupportDir := homedir.MustExpand(SupportDir)
+		fmt.Printf("* Removed all Puma-dev CA certs from macOS keychain.\n")
+		fmt.Printf("! Before re-installing, please delete %s\n", expandedSupportDir)
 	}
 
 	for _, d := range domains {

--- a/dev/setup_darwin_test.go
+++ b/dev/setup_darwin_test.go
@@ -30,10 +30,6 @@ func TestUninstall_DarwinInteractive(t *testing.T) {
 	if m := flag.Lookup("test.run").Value.String(); m == "" || !regexp.MustCompile(m).MatchString(t.Name()) {
 		t.Skip("interactive test must be specified with -test.run=DarwinInteractive")
 	}
-	expandedHomeDir := homedir.MustExpand(SupportDir)
-
-	assert.DirExists(t, expandedHomeDir)
-
 	launchAgentDir, _, cleanupFunc := installIntoTestContext(t)
 	defer cleanupFunc()
 
@@ -42,7 +38,6 @@ func TestUninstall_DarwinInteractive(t *testing.T) {
 	Uninstall(launchAgentDir, []string{"test", "localhost"})
 
 	assert.Error(t, exec.Command("launchctl", "list", "io.puma.dev").Run())
-	assert.NoDirExists(t, expandedHomeDir)
 }
 
 func TestInstallIntoSystem_FailsAsSuperuser(t *testing.T) {

--- a/dev/setup_darwin_test.go
+++ b/dev/setup_darwin_test.go
@@ -30,6 +30,9 @@ func TestUninstall_DarwinInteractive(t *testing.T) {
 	if m := flag.Lookup("test.run").Value.String(); m == "" || !regexp.MustCompile(m).MatchString(t.Name()) {
 		t.Skip("interactive test must be specified with -test.run=DarwinInteractive")
 	}
+	expandedHomeDir := homedir.MustExpand(SupportDir)
+
+	assert.DirExists(t, expandedHomeDir)
 
 	launchAgentDir, _, cleanupFunc := installIntoTestContext(t)
 	defer cleanupFunc()
@@ -39,7 +42,7 @@ func TestUninstall_DarwinInteractive(t *testing.T) {
 	Uninstall(launchAgentDir, []string{"test", "localhost"})
 
 	assert.Error(t, exec.Command("launchctl", "list", "io.puma.dev").Run())
-	assert.NoDirExists(t, SupportDir)
+	assert.NoDirExists(t, expandedHomeDir)
 }
 
 func TestInstallIntoSystem_FailsAsSuperuser(t *testing.T) {

--- a/dev/setup_darwin_test.go
+++ b/dev/setup_darwin_test.go
@@ -1,10 +1,12 @@
 package dev
 
 import (
+	"flag"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"testing"
 
@@ -14,41 +16,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInstallIntoSystem(t *testing.T) {
-	appLinkDir, _ := ioutil.TempDir("", ".puma-dev")
-	libDir, _ := ioutil.TempDir("", "Library")
-	logFilePath := filepath.Join(libDir, "Logs", "puma-dev.log")
-	launchAgentDir := filepath.Join(libDir, "LaunchAgents")
-	expectedPlistPath := filepath.Join(launchAgentDir, "io.puma.dev.plist")
-	assert.NoDirExists(t, launchAgentDir)
+func TestInstallIntoSystem_VerifyLaunchAgent(t *testing.T) {
+	launchAgentDir, expectedPlistPath, cleanupFunc := installIntoTestContext(t)
+	defer cleanupFunc()
 
-	defer func() {
-		exec.Command("launchctl", "unload", expectedPlistPath).Run()
-		os.RemoveAll(appLinkDir)
-		os.RemoveAll(logFilePath)
-		os.RemoveAll(libDir)
-	}()
-
-	generateLivePumaDevCertIfNotExist(t)
-
-	err := InstallIntoSystem(&InstallIntoSystemArgs{
-		ListenPort:         10080,
-		TlsPort:            10443,
-		Domains:            "test:localhost",
-		Timeout:            "5s",
-		ApplinkDirPath:     appLinkDir,
-		LaunchAgentDirPath: launchAgentDir,
-		LogfilePath:        logFilePath,
-	})
-
-	assert.NoError(t, err)
-
-	assert.DirExists(t, launchAgentDir)
 	assert.FileExists(t, expectedPlistPath)
-	AssertDirUmask(t, "0755", launchAgentDir)
+	assertDirUmask(t, "0755", launchAgentDir)
+
+	assert.NoError(t, exec.Command("launchctl", "list", "io.puma.dev").Run())
 }
 
-func TestInstallIntoSystem_superuser(t *testing.T) {
+func TestUninstall_DarwinInteractive(t *testing.T) {
+	if m := flag.Lookup("test.run").Value.String(); m == "" || !regexp.MustCompile(m).MatchString(t.Name()) {
+		t.Skip("interactive test must be specified with -test.run=DarwinInteractive")
+	}
+
+	launchAgentDir, _, cleanupFunc := installIntoTestContext(t)
+	defer cleanupFunc()
+
+	assert.NoError(t, exec.Command("launchctl", "list", "io.puma.dev").Run())
+
+	Uninstall(launchAgentDir, []string{"test", "localhost"})
+
+	assert.Error(t, exec.Command("launchctl", "list", "io.puma.dev").Run())
+	assert.NoDirExists(t, SupportDir)
+}
+
+func TestInstallIntoSystem_FailsAsSuperuser(t *testing.T) {
 	os.Setenv("SUDO_USER", os.Getenv("USER"))
 	defer os.Unsetenv("SUDO_USER")
 
@@ -65,7 +59,39 @@ func TestInstallIntoSystem_superuser(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func AssertDirUmask(t *testing.T, expectedUmask, path string) {
+func installIntoTestContext(t *testing.T) (string, string, func()) {
+	appLinkDir, _ := ioutil.TempDir("", ".puma-dev")
+	libDir, _ := ioutil.TempDir("", "Library")
+	logFilePath := filepath.Join(libDir, "Logs", "puma-dev.log")
+	launchAgentDir := filepath.Join(libDir, "LaunchAgents")
+	assert.NoDirExists(t, launchAgentDir)
+
+	expectedPlistPath := filepath.Join(launchAgentDir, "io.puma.dev.plist")
+
+	cleanup := func() {
+		exec.Command("launchctl", "unload", expectedPlistPath).Run()
+		os.RemoveAll(appLinkDir)
+		os.RemoveAll(logFilePath)
+		os.RemoveAll(libDir)
+	}
+
+	generateLivePumaDevCertIfNotExist(t)
+
+	err := InstallIntoSystem(&InstallIntoSystemArgs{
+		ListenPort:         10080,
+		TlsPort:            10443,
+		Domains:            "test:localhost",
+		Timeout:            "5s",
+		ApplinkDirPath:     appLinkDir,
+		LaunchAgentDirPath: launchAgentDir,
+		LogfilePath:        logFilePath,
+	})
+	assert.NoError(t, err)
+
+	return launchAgentDir, expectedPlistPath, cleanup
+}
+
+func assertDirUmask(t *testing.T, expectedUmask, path string) {
 	info, err := os.Stat(path)
 	if !assert.NoError(t, err) {
 		assert.True(t, info.IsDir())

--- a/dev/ssl_darwin_test.go
+++ b/dev/ssl_darwin_test.go
@@ -1,68 +1,12 @@
 package dev
 
 import (
-	"flag"
-	"fmt"
-	"log"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 
 	. "github.com/puma/puma-dev/dev/devtest"
 	"github.com/puma/puma-dev/homedir"
 	"github.com/stretchr/testify/assert"
 )
-
-func deleteAllPumaDevCAFromDefaultKeychain() {
-	forEachPumaDevKeychainCertSha := func(subCommand string) string {
-		return fmt.Sprintf(`for sha in $(security find-certificate -a -c "Puma-dev CA" -Z | awk '/SHA-1/ {print $3}'); do %s; done`, subCommand)
-	}
-
-	if err := exec.Command("sh", "-c", forEachPumaDevKeychainCertSha("security delete-certificate -Z $sha")).Run(); err != nil {
-		panic(err)
-	}
-
-	log.Println("! NOTICE - REMOVED ALL CERTS LIKE \"Puma-dev CA\" FROM THE DEFAULT macOS KEYCHAIN")
-}
-
-func TestSetupOurCert_ensureNotWorldReadable(t *testing.T) {
-	t.Skip("not implemented yet - https://github.com/puma/puma-dev/issues/215")
-}
-
-func TestSetupOurCert_InteractiveCertificateInstall(t *testing.T) {
-	if flag.Lookup("test.run").Value.String() != t.Name() {
-		t.Skipf("interactive test must be specified with -test.run=%s", t.Name())
-	}
-
-	liveSupportPath := homedir.MustExpand(SupportDir)
-	liveCertPath := filepath.Join(liveSupportPath, "cert.pem")
-	liveKeyPath := filepath.Join(liveSupportPath, "key.pem")
-
-	os.Remove(liveCertPath)
-	os.Remove(liveKeyPath)
-
-	assert.False(t, FileExists(liveCertPath))
-	assert.False(t, FileExists(liveKeyPath))
-
-	certInstallStdOut := WithStdoutCaptured(func() {
-		err := SetupOurCert()
-		assert.Nil(t, err)
-
-		assert.True(t, FileExists(liveCertPath))
-		assert.True(t, FileExists(liveKeyPath))
-	})
-
-	assert.Regexp(t, "^\\* Adding certification to login keychain as trusted\\n", certInstallStdOut)
-	assert.Regexp(t, "! There is probably a dialog open that requires you to authenticate\\n", certInstallStdOut)
-	assert.Regexp(t, "\\* Certificates setup, ready for https operations!\\n$", certInstallStdOut)
-
-	defer func() {
-		deleteAllPumaDevCAFromDefaultKeychain()
-		os.Remove(liveCertPath)
-		os.Remove(liveKeyPath)
-	}()
-}
 
 func TestTrustCert_Darwin_noCertProvided(t *testing.T) {
 	stdOut := WithStdoutCaptured(func() {
@@ -73,4 +17,11 @@ func TestTrustCert_Darwin_noCertProvided(t *testing.T) {
 
 	assert.Regexp(t, "^* Adding certification to login keychain as trusted", stdOut)
 	assert.Regexp(t, "! There is probably a dialog open that requires you to authenticate\\n$", stdOut)
+}
+
+func TestLoginKeychain(t *testing.T) {
+	expected := homedir.MustExpand("~/Library/Keychains/login.keychain-db")
+	actual, err := loginKeyChain()
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
Resolves #84

The `security` command isn't correctly installing the generated Puma-dev CA into the default, login macOS keychain. This PR ensures that the CA is trusted by the current user at `-install` and that `-uninstall` will untrust any such CAs and delete them from disk.

~~Note: If this gets too unwieldy, might split up into 2-3 PRs.~~ Not worth it, based on where this ended up.

## Changes
- [x] Remove hardcoded keychain paths in favor of `security login-keychain`
- [x] Remove `-d -r trustRoot` flags from `security` command to trust cert. It doesn't result in correct trust settings.
- [x] Create an "interactive" test convention so we can run end-to-end keychain tests that require a macOS system password prompt
- [x] Pull out default paths into `main_darwin`
- [x] Expose `DeleteAllPumaDevCAFromDefaultKeychain` to `puma-dev -uninstall` to correctly untrust and delete generated CA certs.
- [x] Test `puma-dev -install`
- [x] ~Test that CA cert can generate valid certs for a puma-dev hostname.~ Didn't end up doing this. It's effectively just testing X509, which feels redundant.