### PR TITLE
add support for .pumaenv file

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Puma-dev supports loading environment variables before puma starts. It checks fo
 * `.env`
 * `.powrc`
 * `.powenv`
+* `.pumaenv`
 
 Additionally, puma-dev uses a few environment variables to control how puma is started that you can overwrite in your loaded shell config.
 

--- a/dev/app.go
+++ b/dev/app.go
@@ -251,6 +251,10 @@ if test -e .powenv; then
 	source .powenv
 fi
 
+if test -e .pumaenv; then
+	source .pumaenv
+fi
+
 if test -e Gemfile && bundle exec puma -V &>/dev/null; then
 	exec bundle exec puma -C $CONFIG --tag puma-dev:%s -w $WORKERS -t 0:$THREADS -b unix:%s
 fi


### PR DESCRIPTION
Since using `.powenv` feels wrong, since this is not pow, and `.env` conflicts with Docker's default `.env` loading (Docker only supports plain variable assignments), I figured it might be good to have a Puma-named env file.