### PR TITLE
Allow puma config to overwrite threads and workers

### DIFF
--- a/dev/app.go
+++ b/dev/app.go
@@ -256,10 +256,10 @@ if test -e .pumaenv; then
 fi
 
 if test -e Gemfile && bundle exec puma -V &>/dev/null; then
-	exec bundle exec puma -C $CONFIG --tag puma-dev:%s -w $WORKERS -t 0:$THREADS -b unix:%s
+	exec bundle exec puma -w $WORKERS -t 0:$THREADS -C $CONFIG --tag puma-dev:%s -b unix:%s
 fi
 
-exec puma -C $CONFIG --tag puma-dev:%s -w $WORKERS -t 0:$THREADS -b unix:%s'
+exec puma -w $WORKERS -t 0:$THREADS -C $CONFIG --tag puma-dev:%s -b unix:%s'
 `
 
 func (pool *AppPool) LaunchApp(name, dir string) (*App, error) {


### PR DESCRIPTION
Currently when using the following puma config file, the `threads` and `workers` options are ignored because the `-w` and `-t` flags appear after the `-C` flag and will override the workers and threads settings.

```ruby
#!/usr/bin/env puma

threads ENV.fetch('PUMA_MIN_THREADS', 1), ENV.fetch('PUMA_MAX_THREADS', 1)
worker_boot_timeout ENV.fetch('PUMA_WORKER_BOOT_TIMEOUT', 60)
worker_timeout ENV.fetch('PUMA_WORKER_TIMEOUT', 60)
workers ENV.fetch('PUMA_WORKERS', 1)

```

The change in this PR allows the puma config file to be authoritative.