### PR TITLE
Add logging of no-serve-public-paths and add -install support for it

### DIFF
--- a/cmd/puma-dev/main_darwin.go
+++ b/cmd/puma-dev/main_darwin.go
@@ -178,7 +178,10 @@ func main() {
 	http.Pool = &pool
 	http.Debug = *fDebug
 	http.Events = &events
-	http.IgnoredStaticPaths = strings.Split(*fNoServePublicPaths, ":")
+	if len(*fNoServePublicPaths) > 0 {
+		http.IgnoredStaticPaths = strings.Split(*fNoServePublicPaths, ":")
+		fmt.Printf("* Ignoring files under: public{%s}\n", strings.Join(http.IgnoredStaticPaths, ", "))
+	}
 
 	http.Setup()
 

--- a/cmd/puma-dev/main_darwin.go
+++ b/cmd/puma-dev/main_darwin.go
@@ -80,6 +80,7 @@ func main() {
 			LogfilePath:        LogFilePath,
 			Timeout:            (*fTimeout).String(),
 			TlsPort:            *fInstallTLS,
+			NoServePublicPaths: *fNoServePublicPaths,
 		})
 
 		if err != nil {

--- a/cmd/puma-dev/main_linux.go
+++ b/cmd/puma-dev/main_linux.go
@@ -100,7 +100,10 @@ func main() {
 	http.Pool = &pool
 	http.Debug = *fDebug
 	http.Events = &events
-	http.IgnoredStaticPaths = strings.Split(*fNoServePublicPaths, ":")
+	if len(*fNoServePublicPaths) > 0 {
+		http.IgnoredStaticPaths = strings.Split(*fNoServePublicPaths, ":")
+		fmt.Printf("* Ignoring files under: public{%s}\n", strings.Join(http.IgnoredStaticPaths, ", "))
+	}
 
 	http.Setup()
 

--- a/dev/http.go
+++ b/dev/http.go
@@ -192,6 +192,9 @@ func (h *HTTPServer) shouldServePublicPathForApp(a *App, req *http.Request) bool
 
 	for _, ignoredPath := range h.IgnoredStaticPaths {
 		if strings.HasPrefix(reqPath, ignoredPath) {
+			if h.Debug {
+				fmt.Fprintf(os.Stdout, "Not serving '%s' as it matches a path in no-serve-public-paths\n", reqPath)
+			}
 			return false
 		}
 	}

--- a/dev/setup_darwin.go
+++ b/dev/setup_darwin.go
@@ -103,6 +103,7 @@ type InstallIntoSystemArgs struct {
 	LaunchAgentDirPath string
 	Domains            string
 	Timeout            string
+	NoServePublicPaths string
 }
 
 func InstallIntoSystem(config *InstallIntoSystemArgs) error {
@@ -137,6 +138,8 @@ func InstallIntoSystem(config *InstallIntoSystemArgs) error {
      <string>-d</string>
      <string>%s</string>
      <string>-timeout</string>
+     <string>%s</string>
+     <string>-no-serve-public-paths</string>
      <string>%s</string>
    </array>
    <key>KeepAlive</key>
@@ -181,7 +184,7 @@ func InstallIntoSystem(config *InstallIntoSystemArgs) error {
 
 	err = ioutil.WriteFile(
 		plist,
-		[]byte(fmt.Sprintf(userTemplate, binPath, dir, config.Domains, config.Timeout, config.ListenPort, config.TlsPort, logPath, logPath)),
+		[]byte(fmt.Sprintf(userTemplate, binPath, dir, config.Domains, config.Timeout, config.NoServePublicPaths, config.ListenPort, config.TlsPort, logPath, logPath)),
 		0644,
 	)
 

--- a/dev/setup_darwin_test.go
+++ b/dev/setup_darwin_test.go
@@ -49,6 +49,7 @@ func TestInstallIntoSystem_FailsAsSuperuser(t *testing.T) {
 		TlsPort:            10443,
 		Domains:            "test:localhost",
 		Timeout:            "5s",
+		NoServePublicPaths: "",
 		ApplinkDirPath:     "/tmp/gotest-dummy-applinkdir",
 		LaunchAgentDirPath: "/tmp/gotest-dummy-launchagent",
 		LogfilePath:        "/tmp/gotest-dummy-logs/dummy.log",
@@ -80,6 +81,7 @@ func installIntoTestContext(t *testing.T) (string, string, func()) {
 		TlsPort:            10443,
 		Domains:            "test:localhost",
 		Timeout:            "5s",
+		NoServePublicPaths: ""
 		ApplinkDirPath:     appLinkDir,
 		LaunchAgentDirPath: launchAgentDir,
 		LogfilePath:        logFilePath,

--- a/dev/setup_darwin_test.go
+++ b/dev/setup_darwin_test.go
@@ -81,7 +81,7 @@ func installIntoTestContext(t *testing.T) (string, string, func()) {
 		TlsPort:            10443,
 		Domains:            "test:localhost",
 		Timeout:            "5s",
-		NoServePublicPaths: ""
+		NoServePublicPaths: "",
 		ApplinkDirPath:     appLinkDir,
 		LaunchAgentDirPath: launchAgentDir,
 		LogfilePath:        logFilePath,


### PR DESCRIPTION
Merge target is: https://github.com/puma/puma-dev/pull/262

This PR adds some simple logging of the no-serve-public-paths option, with more detail when `-debug` is set, as well as including it in the launch agent plist.

See conversation in https://github.com/puma/puma-dev/issues/260 for more context