### PR TITLE
serve dir/index.html when browsing to dir/

### DIFF
--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -262,6 +262,13 @@ func runPlatformAgnosticTestScenarios(t *testing.T) {
 		assert.Equal(t, "<html><h1>public/index.html</h1></html>", getURLWithHost(t, reqURL, statusHost))
 	})
 
+  t.Run("static-site public/ serves index.html", func(t *testing.T) {
+    reqURL := fmt.Sprintf("http://localhost:%d/", *fHTTPPort)
+    statusHost := "static-site"
+
+    assert.Equal(t, "<html><h1>public/index.html</h1></html>", getURLWithHost(t, reqURL, statusHost))
+  })
+
 	t.Run("static-site public/subfolder/index.html", func(t *testing.T) {
 		reqURL := fmt.Sprintf("http://localhost:%d/subfolder/index.html", *fHTTPPort)
 		statusHost := "static-site"

--- a/dev/http.go
+++ b/dev/http.go
@@ -186,10 +186,6 @@ func (h *HTTPServer) shouldServePublicPathForApp(a *App, req *http.Request) bool
 		return false
 	}
 
-	if reqPath == "/" {
-		return false
-	}
-
 	for _, ignoredPath := range h.IgnoredStaticPaths {
 		if strings.HasPrefix(reqPath, ignoredPath) {
 			if h.Debug {


### PR DESCRIPTION
Very naive patch that should allow puma-dev to serve the `public/index.html` when browsing to `/`.

I added a passing test and did not break any existing so I am cautiously optimistic.
However I **do not understand** the original intention of the removed code 

```go
if reqPath == "/" {
  return false
}
```
