### PR TITLE
Prevent apps with the same folder name to colide

### DIFF
--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/sha1"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -237,8 +238,12 @@ func runPlatformAgnosticTestScenarios(t *testing.T) {
 			panic(err)
 		}
 
-		assert.NoError(t, pollForEvent(t, "rack-hi-puma", "killing_app", "restart.txt touched"))
-		assert.NoError(t, pollForEvent(t, "rack-hi-puma", "shutdown", ""))
+		appRoot := filepath.Join(ProjectRoot, "etc", "rack-hi-puma")
+		h := sha1.New()
+		h.Write([]byte(appRoot))
+		appName := fmt.Sprintf("rack-hi-puma-%.4x", h.Sum(nil))
+		assert.NoError(t, pollForEvent(t, appName, "killing_app", "restart.txt touched"))
+		assert.NoError(t, pollForEvent(t, appName, "shutdown", ""))
 	})
 
 	t.Run("unknown app", func(t *testing.T) {

--- a/dev/app.go
+++ b/dev/app.go
@@ -3,6 +3,7 @@ package dev
 import (
 	"bufio"
 	"bytes"
+	"crypto/sha1"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -514,8 +515,10 @@ func (a *AppPool) App(name string) (*App, error) {
 	destStat, err := os.Stat(destPath)
 	if err == nil {
 		destName := destStat.Name()
-		if destName != canonicalName {
-			canonicalName = destName
+		if destName != name {
+			h := sha1.New()
+			h.Write([]byte(destPath))
+			canonicalName = fmt.Sprintf("%s-%.4x", destStat.Name(), h.Sum(nil))
 			aliasName = name
 		}
 	}


### PR DESCRIPTION
# Goal

Before this commit if two apps were resolving their symlinks to distinct folders with the same name, the first app booted was used to serve queries targeting the other app.
example:
```
ls -la ~/.puma-dev/
lrwxr-xr-x    1 vincent  staff    37  4 jan 15:54 content -> /Users/vincent/Projects/content/rails
lrwxr-xr-x    1 vincent  staff    38 24 déc 11:18 platform -> /Users/vincent/Projects/platform/rails
```
both content and platform rails app were served by the first of the two apps being booted

With this commit a checksum of the full app path is being added to the app name, which maintain the existing behavior of having a single app booted even if several symlinks are targeting it, but distinct folders with the same name are now treated as different apps

# consequences

logs are now displaying lines with the app name suffixed by the folder path checksum:

```
rails-4506dc3c[29999]: - Gracefully stopping, waiting for requests to finish
rails-deadc98a[29050]: - Gracefully stopping, waiting for requests to finish
```