### PR TITLE
Fix .env sourcing overwriting existing ENV variables

### DIFF
--- a/dev/app.go
+++ b/dev/app.go
@@ -241,7 +241,9 @@ if test -e ~/.powconfig; then
 fi
 
 if test -e .env; then
+	original_env=$(printenv)
 	source .env
+	eval $original_env # restore any previously existing ENV vars overwritten by .env
 fi
 
 if test -e .powrc; then


### PR DESCRIPTION
Potential fix for: https://github.com/puma/puma-dev/issues/268

This implementation seems simpler than preventing existing ENV variables from being sourced in the first place.

Not sure if we should apply the same logic to the other .env file variants as well?