### PR TITLE
mention GNU/Linux support in homebrew 🐧

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ First, ensure that the [`puma`](https://github.com/puma/puma) gem is installed. 
 gem 'puma'
 ```
 
-### Homebrew on macOS
+### Homebrew on macOS or GNU/Linux
 `brew install puma/puma/puma-dev`
 
 ### Pre-built Binaries


### PR DESCRIPTION
Currently the README only mentions [`Homebrew on macOS`](https://github.com/alexanderadam/puma-dev#homebrew-on-macos) which makes sense, since the homebrew package didn't have GNU/Linux support.

[It was fixed to the Mac binary](https://github.com/puma/homebrew-puma/issues/4).

I created [a small PR to finally fix this](https://github.com/puma/homebrew-puma/pull/12). Thus it is finally installable on GNU/Linux, too via homebrew after this is merged.

Therefore I thought we could change the headline in the README as well. :wink: 

**PS:** Thank you so much for `puma-dev` :pray: 