### PR TITLE
Allow opt-out of dotfile sourcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,15 @@ Puma-dev supports loading environment variables before puma starts. It checks fo
 * `.powenv`
 * `.pumaenv`
 
-Additionally, puma-dev uses a few environment variables to control how puma is started that you can overwrite in your loaded shell config.
+You can prevent puma-dev from loading any of these environment files by setting a corresponding environment variable to '0':
+
+* `PUMADEV_SOURCE_POWCONFIG=0`
+* `PUMADEV_SOURCE_ENV=0`
+* `PUMADEV_SOURCE_POWRC=0`
+* `PUMADEV_SOURCE_POWENV=0`
+* `PUMADEV_SOURCE_PUMAENV=0`
+
+Additionally, puma-dev uses a few other environment variables to control how puma is started that you can overwrite in your loaded shell config.
 
 * `CONFIG`: A puma configuration file to load, usually something like `config/puma-dev.rb`. Defaults to no config.
 * `THREADS`: How many threads puma should use concurrently. Defaults to 5.

--- a/dev/app.go
+++ b/dev/app.go
@@ -236,23 +236,23 @@ func (a *App) Log() string {
 const executionShell = `exec bash -c '
 cd %s
 
-if test -e ~/.powconfig; then
+if test -e ~/.powconfig && [ "$PUMADEV_SOURCE_POWCONFIG" != "0" ]; then
 	source ~/.powconfig
 fi
 
-if test -e .env; then
+if test -e .env && [ "$PUMADEV_SOURCE_ENV" != "0" ]; then
 	source .env
 fi
 
-if test -e .powrc; then
+if test -e .powrc && [ "$PUMADEV_SOURCE_POWRC" != "0" ]; then
 	source .powrc
 fi
 
-if test -e .powenv; then
+if test -e .powenv && [ "$PUMADEV_SOURCE_POWENV" != "0" ]; then
 	source .powenv
 fi
 
-if test -e .pumaenv; then
+if test -e .pumaenv && [ "$PUMADEV_SOURCE_PUMAENV" != "0" ]; then
 	source .pumaenv
 fi
 


### PR DESCRIPTION
As an alternative approach to #268 than #271, I wanted to explore allowing the execution shell to leverage its environment to individually toggle each dotfile on or off.

I'm pretty flexible on var names here and would be happy to add tests if needed, I just didn't see any for the file or behaviors in question.

Let me know what else you'd need to give this a try!