### PR TITLE
Fix: sharing app instances with different hostnames not working

### DIFF
--- a/dev/app.go
+++ b/dev/app.go
@@ -521,10 +521,11 @@ func (a *AppPool) App(name string) (*App, error) {
 	destStat, err := os.Stat(destPath)
 	if err == nil {
 		destName := destStat.Name()
+		h := sha1.New()
+		h.Write([]byte(destPath))
+		canonicalName = fmt.Sprintf("%s-%.4x", destStat.Name(), h.Sum(nil))
+
 		if destName != name {
-			h := sha1.New()
-			h.Write([]byte(destPath))
-			canonicalName = fmt.Sprintf("%s-%.4x", destStat.Name(), h.Sum(nil))
 			aliasName = name
 		}
 	}


### PR DESCRIPTION
This fixes a problem where it [fails to reuse the same instance of the app when using multiple hostnames with different names](https://github.com/puma/puma-dev/issues/280) (multiple symlinks pointing to the same folder).

The bug was introduced in #270. The patch is based on adding the checksum in all cases when a symlink is involved, not only when the names don't match. If not, it can happen that it's not added if the name matches for the first execution, which
results in not finding the app instance later, resulting in an error "There is already a server bound to..."

Fixes #280

cc @hellvinz @nonrational 