### PR TITLE
Add support for multipart TLDs

### DIFF
--- a/cmd/puma-dev/main_darwin.go
+++ b/cmd/puma-dev/main_darwin.go
@@ -179,6 +179,7 @@ func main() {
 	http.Pool = &pool
 	http.Debug = *fDebug
 	http.Events = &events
+	http.Domains = domains
 	if len(*fNoServePublicPaths) > 0 {
 		http.IgnoredStaticPaths = strings.Split(*fNoServePublicPaths, ":")
 		fmt.Printf("* Ignoring files under: public{%s}\n", strings.Join(http.IgnoredStaticPaths, ", "))

--- a/cmd/puma-dev/main_linux.go
+++ b/cmd/puma-dev/main_linux.go
@@ -100,6 +100,7 @@ func main() {
 	http.Pool = &pool
 	http.Debug = *fDebug
 	http.Events = &events
+	http.Domains = domains
 	if len(*fNoServePublicPaths) > 0 {
 		http.IgnoredStaticPaths = strings.Split(*fNoServePublicPaths, ":")
 		fmt.Printf("* Ignoring files under: public{%s}\n", strings.Join(http.IgnoredStaticPaths, ", "))

--- a/dev/http_test.go
+++ b/dev/http_test.go
@@ -49,3 +49,17 @@ func TestHttp_removeTLD_nipIoDots(t *testing.T) {
 
 	assert.Equal(t, "effective-invention", str)
 }
+
+func TestHttp_removeTLD_multipartTLD(t *testing.T) {
+	testHttp.Domains = []string{"co.test"}
+	str := testHttp.removeTLD("confusing-riddle.co.test")
+
+	assert.Equal(t, "confusing-riddle", str)
+}
+
+func TestHttp_removeTLD_multipartTLDSimilarToShorterOne(t *testing.T) {
+	testHttp.Domains = []string{"test", "co.test"}
+	str := testHttp.removeTLD("confusing-riddle.co.test")
+
+	assert.Equal(t, "confusing-riddle", str)
+}


### PR DESCRIPTION
The current implementation of puma-dev doesn't actually take the configured domains into account when resolving apps, so anything other than a very simple TLD fails to resolve properly. This PR attempts to remove the configured TLDs from the requested host before falling back to the old method of just stripping everything after and including the last period from the host.