### PR TITLE
Restore file default security contexts note

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ sudo systemctl enable puma-dev
 sudo systemctl start puma-dev
 ```
 
+On systems with SELinux you may have to run `restorecon /path/to/puma-dev` in order to run it.
+
 ---
 
 ## Usage


### PR DESCRIPTION
Today while using a new installation of Fedora, I ran into SELinux issues. Running `restorecon` resolved them.