### PR TITLE
Add test for presence of X-Forwarded-For and X-Forwarded-Proto HTTP headers

### DIFF
--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -165,6 +165,8 @@ func getURLWithHost(t *testing.T, url string, host string) string {
 	return strings.TrimSpace(string(bodyBytes))
 }
 
+// function to parse dumped request headers sent by puma-dev to the origin server
+// for details see etc/rack-request-headers-dump/config.ru
 func parseDumpedHTTPHeadersFromBody(body string) map[string]string {
 	dumpedHeadersLines := strings.Split(body, "\n")
 

--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -322,7 +322,7 @@ func runPlatformAgnosticTestScenarios(t *testing.T) {
 
 		dumpedHeaders := parseDumpedHTTPHeadersFromBody(getURLWithHost(t, reqURL, statusHost))
 
-		assert.Equal(t, "127.0.0.1", dumpedHeaders["HTTP_X_FORWARDED_FOR"])
+		assert.Regexp(t, `127\.0\.0\.1|::1`, dumpedHeaders["HTTP_X_FORWARDED_FOR"])
 		assert.Equal(t, "http", dumpedHeaders["HTTP_X_FORWARDED_PROTO"])
 	})
 
@@ -332,7 +332,7 @@ func runPlatformAgnosticTestScenarios(t *testing.T) {
 
 		dumpedHeaders := parseDumpedHTTPHeadersFromBody(getURLWithHost(t, reqURL, statusHost))
 
-		assert.Equal(t, "127.0.0.1", dumpedHeaders["HTTP_X_FORWARDED_FOR"])
+		assert.Regexp(t, `^127\.0\.0\.1|::1`, dumpedHeaders["HTTP_X_FORWARDED_FOR"])
 		assert.Equal(t, "https", dumpedHeaders["HTTP_X_FORWARDED_PROTO"])
 	})
 }

--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/sha1"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -144,7 +145,14 @@ func getURLWithHost(t *testing.T, url string, host string) string {
 	req, _ := http.NewRequest("GET", url, nil)
 	req.Host = host
 
-	resp, err := http.DefaultClient.Do(req)
+	// we don't care about checking certs in tests
+	// the generated cert will not be trusted by the test runner
+	insecureTransport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	insecureClient := &http.Client{Transport: insecureTransport}
+
+	resp, err := insecureClient.Do(req)
 
 	if err != nil {
 		assert.FailNow(t, err.Error())

--- a/cmd/puma-dev/main_test.go
+++ b/cmd/puma-dev/main_test.go
@@ -293,4 +293,21 @@ func runPlatformAgnosticTestScenarios(t *testing.T) {
 
 		assert.Equal(t, "rack wuz here", getURLWithHost(t, reqURL, statusHost))
 	})
+
+	t.Run("request-headers-dump contains X-Forwarded-* headers", func(t *testing.T) {
+		reqURL := fmt.Sprintf("https://localhost:%d/", *fTLSPort)
+		statusHost := "request-headers-dump"
+
+		dumpedHeadersResponse := getURLWithHost(t, reqURL, statusHost)
+		dumpedHeadersResponseLines := strings.Split(dumpedHeadersResponse, "\n")
+
+		dumpedHeaders := make(map[string]string)
+		for _, pairString := range dumpedHeadersResponseLines {
+			pair := strings.SplitN(pairString, " ", 2)
+			dumpedHeaders[pair[0]] = pair[1]
+		}
+
+		assert.Equal(t, "127.0.0.1", dumpedHeaders["HTTP_X_FORWARDED_FOR"])
+		assert.Equal(t, "https", dumpedHeaders["HTTP_X_FORWARDED_PROTO"])
+	})
 }

--- a/dev/devtest/testutils.go
+++ b/dev/devtest/testutils.go
@@ -220,8 +220,8 @@ func LinkTestApps(t *testing.T, workingDirPath string, testAppsToLink map[string
 
 func LinkAllTestApps(t *testing.T, workingDirPath string) func() {
 	testAppsToLink := map[string]string{
-		"hipuma":      "rack-hi-puma",
-		"static-site": "static-hi-puma",
+		"hipuma":               "rack-hi-puma",
+		"static-site":          "static-hi-puma",
 		"request-headers-dump": "rack-request-headers-dump",
 	}
 

--- a/dev/devtest/testutils.go
+++ b/dev/devtest/testutils.go
@@ -222,6 +222,7 @@ func LinkAllTestApps(t *testing.T, workingDirPath string) func() {
 	testAppsToLink := map[string]string{
 		"hipuma":      "rack-hi-puma",
 		"static-site": "static-hi-puma",
+		"request-headers-dump": "rack-request-headers-dump",
 	}
 
 	return LinkTestApps(t, workingDirPath, testAppsToLink)

--- a/dev/http.go
+++ b/dev/http.go
@@ -144,6 +144,12 @@ func (h *HTTPServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	if req.TLS == nil {
+		req.Header.Set("X-Forwarded-Proto", "http")
+	} else {
+		req.Header.Set("X-Forwarded-Proto", "https")
+	}
+
 	req.URL.Scheme, req.URL.Host = app.Scheme, app.Address()
 	h.proxy.ServeHTTP(w, req)
 }

--- a/etc/rack-request-headers-dump/config.ru
+++ b/etc/rack-request-headers-dump/config.ru
@@ -1,0 +1,11 @@
+class Application
+  def call(env)
+    status  = 200
+    headers = { "Content-Type" => "application/json" }
+    body    = [ env.select { |k, v| k.start_with?('HTTP_') }.map { |(k, v)| [k, v].join(' ') }.join("\n") ]
+
+    [status, headers, body]
+  end
+end
+
+run Application.new


### PR DESCRIPTION
Presence and content of `X-Forwarded-For` and `X-Forwarded-Proto` is checked in requests made to the origin server.

`X-Forwarded-For` is checked to be equal to `127.0.0.1`. `X-Forwarded-Proto` is checked to be equal to `https` because the test request is made using HTTPS.

These headers are expected to be present when requests go through reverse proxy.

Especially `X-Forwarded-Proto` is required when proxy terminates SSL and forwards request to the origin server using plain HTTP. When this header is missing it can cause infinite redirect loop back to HTTPS.

Checks for issue reported in #298 caused by #292. This test fails on `v0.18.0` and passes on `v0.17.0`.