### PR TITLE
Add `-listen-address` and `-install-listen-address` flags for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ Puma-dev will startup by default using the directory `~/.puma-dev`, looking for 
 
 Running `puma-dev` in this way will require you to use the listed http port, which is `9280` by default.
 
+On macOS, you can specify where the server should listen with the `-listen-address` flag
+
 ### Coming from v0.2
 
 Puma-dev v0.3 and later use launchd to access privileged ports, so if you installed v0.2, you'll need to remove the firewall rules.

--- a/cmd/puma-dev/main_darwin.go
+++ b/cmd/puma-dev/main_darwin.go
@@ -21,6 +21,7 @@ var (
 	fDNSPort  = flag.Int("dns-port", 9253, "port to listen on dns for")
 	fHTTPPort = flag.Int("http-port", 9280, "port to listen on http for")
 	fTLSPort  = flag.Int("https-port", 9283, "port to listen on https for")
+	fAddress  = flag.String("listen-address", "127.0.0.1", "address to listen on")
 	fDir      = flag.String("dir", "~/.puma-dev", "directory to watch for apps")
 	fTimeout  = flag.Duration("timeout", 15*60*time.Second, "how long to let an app idle for")
 	fPow      = flag.Bool("pow", false, "Mimic pow's settings")
@@ -167,7 +168,7 @@ func main() {
 		fmt.Printf("* HTTPS Server port: %d\n", *fTLSPort)
 	}
 
-	dns := dev.NewDNSResponder(fmt.Sprintf("127.0.0.1:%d", *fDNSPort), domains)
+	dns := dev.NewDNSResponder(fmt.Sprintf("%s:%d", *fAddress, *fDNSPort), domains)
 	go func() {
 		if err := dns.Serve(); err != nil {
 			fmt.Printf("! DNS Server failed: %v\n", err)
@@ -176,8 +177,8 @@ func main() {
 
 	var http dev.HTTPServer
 
-	http.Address = fmt.Sprintf("127.0.0.1:%d", *fHTTPPort)
-	http.TLSAddress = fmt.Sprintf("127.0.0.1:%d", *fTLSPort)
+	http.Address = fmt.Sprintf("%s:%d", *fAddress, *fHTTPPort)
+	http.TLSAddress = fmt.Sprintf("%s:%d", *fAddress, *fTLSPort)
 	http.Pool = &pool
 	http.Debug = *fDebug
 	http.Events = &events

--- a/cmd/puma-dev/main_darwin.go
+++ b/cmd/puma-dev/main_darwin.go
@@ -32,9 +32,10 @@ var (
 	fSetup = flag.Bool("setup", false, "Run system setup")
 	fStop  = flag.Bool("stop", false, "Stop all puma-dev servers")
 
-	fInstall     = flag.Bool("install", false, "Install puma-dev as a user service")
-	fInstallPort = flag.Int("install-port", 80, "Port to run puma-dev on when installed")
-	fInstallTLS  = flag.Int("install-https-port", 443, "Port to run puma-dev for SSL on when installed")
+	fInstall     					= flag.Bool("install", false, "Install puma-dev as a user service")
+	fInstallListenAddress = flag.String("install-listen-address", "0.0.0.0", "address to listen on when installed")
+	fInstallPort 					= flag.Int("install-port", 80, "Port to run puma-dev on when installed")
+	fInstallTLS  					= flag.Int("install-https-port", 443, "Port to run puma-dev for SSL on when installed")
 
 	fCleanup   = flag.Bool("cleanup", false, "Cleanup old system settings")
 	fUninstall = flag.Bool("uninstall", false, "Uninstall puma-dev as a user service")
@@ -79,6 +80,7 @@ func main() {
 			ApplinkDirPath:     *fDir,
 			Domains:            *fDomains,
 			LaunchAgentDirPath: LaunchAgentDirPath,
+			ListenAddress:      *fInstallListenAddress,
 			ListenPort:         *fInstallPort,
 			LogfilePath:        LogFilePath,
 			Timeout:            (*fTimeout).String(),

--- a/dev/setup_darwin.go
+++ b/dev/setup_darwin.go
@@ -98,6 +98,7 @@ func Cleanup() {
 type InstallIntoSystemArgs struct {
 	ListenPort         int
 	TlsPort            int
+	ListenAddress      string
 	LogfilePath        string
 	ApplinkDirPath     string
 	LaunchAgentDirPath string
@@ -151,14 +152,14 @@ func InstallIntoSystem(config *InstallIntoSystemArgs) error {
        <key>Socket</key>
        <dict>
            <key>SockNodeName</key>
-           <string>0.0.0.0</string>
+           <string>%s</string>
            <key>SockServiceName</key>
            <string>%d</string>
        </dict>
        <key>SocketTLS</key>
        <dict>
            <key>SockNodeName</key>
-           <string>0.0.0.0</string>
+           <string>%s</string>
            <key>SockServiceName</key>
            <string>%d</string>
        </dict>
@@ -184,7 +185,7 @@ func InstallIntoSystem(config *InstallIntoSystemArgs) error {
 
 	err = ioutil.WriteFile(
 		plist,
-		[]byte(fmt.Sprintf(userTemplate, binPath, dir, config.Domains, config.Timeout, config.NoServePublicPaths, config.ListenPort, config.TlsPort, logPath, logPath)),
+		[]byte(fmt.Sprintf(userTemplate, binPath, dir, config.Domains, config.Timeout, config.NoServePublicPaths, config.ListenAddress, config.ListenPort, config.ListenAddress, config.TlsPort, logPath, logPath)),
 		0644,
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/vektra/errors v0.0.0-20140903201135-c64d83aba85a
 	golang.org/x/crypto v0.0.0-20200403201458-baeed622b8d8 // indirect
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
-	golang.org/x/sys v0.0.0-20200331124033-c3d80250170d // indirect
+	golang.org/x/sys v0.0.0-20221010170243-090e33056c14 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d h1:nc5K6ox/4lTFbMVSL9WRR81ixkcwXThoiF6yf+R9scA=
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cIyEbeXLBhy5Ha4nevyc=
+golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
This could solve the issues outlined in #306, where users want to specify the addresses they listen to on `puma-dev`.

`-listen-address` defaults to `127.0.0.1`, and `-install-listen-address` to keep existing behavior.

**NOTE: these do not have tests yet, this is my first attempts at working in Go, so it's a starting point and definitely needs reviewed**