### PR TITLE
Support custom app directory location

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ On systems with SELinux you may have to run `restorecon /path/to/puma-dev` in or
 
 Simply symlink your app's directory into `~/.puma-dev`! That's it!
 
-You can use the built-in helper subcommand: `puma-dev link [-n name] [dir]` to link app directories into your puma-dev directory (`~/.puma-dev` by default).
+You can use the built-in helper subcommand: `puma-dev link [-n name] [dir]` to link app directories into your puma-dev directory (`~/.puma-dev` by default, but can be changed with `PUMA_DEV_APP_DIR`).
 
 ### Options
 
@@ -352,4 +352,3 @@ To build puma-dev, follow these steps:
 Tagged builds (e.g `v0.18.0`) will automatically create [pre-release](https://github.com/puma/puma-dev/releases) with artifacts for use in the Homebrew formula.
 
 All [builds with passing tests](https://github.com/puma/puma-dev/actions) will publish binaries that are saved for 90 days.
-

--- a/cmd/puma-dev/main_darwin.go
+++ b/cmd/puma-dev/main_darwin.go
@@ -21,7 +21,7 @@ var (
 	fDNSPort  = flag.Int("dns-port", 9253, "port to listen on dns for")
 	fHTTPPort = flag.Int("http-port", 9280, "port to listen on http for")
 	fTLSPort  = flag.Int("https-port", 9283, "port to listen on https for")
-	fDir      = flag.String("dir", "~/.puma-dev", "directory to watch for apps")
+	fDir      = flag.String("dir", dev.GetEnv("PUMA_DEV_APP_DIR", "~/.puma-dev"), "directory to watch for apps")
 	fTimeout  = flag.Duration("timeout", 15*60*time.Second, "how long to let an app idle for")
 	fPow      = flag.Bool("pow", false, "Mimic pow's settings")
 	fLaunch   = flag.Bool("launchd", false, "Use socket from launchd")

--- a/cmd/puma-dev/main_linux.go
+++ b/cmd/puma-dev/main_linux.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	fDebug              = flag.Bool("debug", false, "enable debug output")
-	fDir                = flag.String("dir", "~/.puma-dev", "directory to watch for apps")
+	fDir                = flag.String("dir", dev.GetEnv("PUMA_DEV_APP_DIR", "~/.puma-dev"), "directory to watch for apps")
 	fDomains            = flag.String("d", "test", "domains to handle, separate with :, defaults to test")
 	fHTTPPort           = flag.Int("http-port", 9280, "port to listen on http for")
 	fNoServePublicPaths = flag.String("no-serve-public-paths", "", "Disable static file server for specific paths under /public")

--- a/dev/get_env.go
+++ b/dev/get_env.go
@@ -1,0 +1,8 @@
+package dev
+
+func GetEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+			return value
+	}
+	return fallback
+}

--- a/dev/get_env.go
+++ b/dev/get_env.go
@@ -2,7 +2,7 @@ package dev
 
 func GetEnv(key, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
-			return value
+		return value
 	}
 	return fallback
 }


### PR DESCRIPTION
There are several spots in the README that talk about the what the default puma-dev directory is (e.g., "~/.puma-dev by default", "Puma-dev will startup by default using the directory ~/.puma-dev"), but there wasn't any indication of how to change the directory to anything other than that default value.

I poked around the code a bit. I've never worked with Go, but as best I could tell that directory was hardcoded. I took a stab at adding the ability to set a custom directory with an environment variable.

I tried to lint and build the changes locally, but something is clearly banged up with my local Go setup. If what I came up with isn't correct, I doubt I would be able to fix it in the amount of time I have to spend on this, but it seemed like a simple change so hopefully it's close and maybe someone else can polish it up if necessary.