### PR TITLE
Support prefixing to puma command

### DIFF
--- a/dev/app.go
+++ b/dev/app.go
@@ -261,7 +261,7 @@ if test -e .pumaenv && [ "$PUMADEV_SOURCE_PUMAENV" != "0" ]; then
 fi
 
 if test -e Gemfile && bundle exec puma -V &>/dev/null; then
-	exec $COMMAND_PREFIX bundle exec puma -C $CONFIG --tag puma-dev:%s -w $WORKERS -t 0:$THREADS -b unix:%s <&2
+	exec $COMMAND_PREFIX bundle exec puma -C $CONFIG --tag puma-dev:%s -w $WORKERS -t 0:$THREADS -b unix:%s
 fi
 
 exec $COMMAND_PREFIX puma -C $CONFIG --tag puma-dev:%s -w $WORKERS -t 0:$THREADS -b unix:%s'

--- a/dev/app.go
+++ b/dev/app.go
@@ -283,7 +283,6 @@ func (pool *AppPool) LaunchApp(name, dir string) (*App, error) {
 		shell = "/bin/bash"
 	}
 
- fmt.Print(executionShell)
 	cmd := exec.Command(shell, "-l", "-i", "-c",
 		fmt.Sprintf(executionShell, dir, name, socket, name, socket))
 

--- a/dev/app.go
+++ b/dev/app.go
@@ -261,10 +261,10 @@ if test -e .pumaenv && [ "$PUMADEV_SOURCE_PUMAENV" != "0" ]; then
 fi
 
 if test -e Gemfile && bundle exec puma -V &>/dev/null; then
-	exec bundle exec puma -C $CONFIG --tag puma-dev:%s -w $WORKERS -t 0:$THREADS -b unix:%s
+	exec $COMMAND_PREFIX bundle exec puma -C $CONFIG --tag puma-dev:%s -w $WORKERS -t 0:$THREADS -b unix:%s <&2
 fi
 
-exec puma -C $CONFIG --tag puma-dev:%s -w $WORKERS -t 0:$THREADS -b unix:%s'
+exec $COMMAND_PREFIX puma -C $CONFIG --tag puma-dev:%s -w $WORKERS -t 0:$THREADS -b unix:%s'
 `
 
 func (pool *AppPool) LaunchApp(name, dir string) (*App, error) {
@@ -283,6 +283,7 @@ func (pool *AppPool) LaunchApp(name, dir string) (*App, error) {
 		shell = "/bin/bash"
 	}
 
+ fmt.Print(executionShell)
 	cmd := exec.Command(shell, "-l", "-i", "-c",
 		fmt.Sprintf(executionShell, dir, name, socket, name, socket))
 

--- a/dev/app.go
+++ b/dev/app.go
@@ -261,7 +261,7 @@ if test -e .pumaenv && [ "$PUMADEV_SOURCE_PUMAENV" != "0" ]; then
 fi
 
 if test -e Gemfile && bundle exec puma -V &>/dev/null; then
-	exec $COMMAND_PREFIX bundle exec puma -C $CONFIG --tag puma-dev:%s -w $WORKERS -t 0:$THREADS -b unix:%s
+	exec bundle exec $COMMAND_PREFIX puma -C $CONFIG --tag puma-dev:%s -w $WORKERS -t 0:$THREADS -b unix:%s
 fi
 
 exec $COMMAND_PREFIX puma -C $CONFIG --tag puma-dev:%s -w $WORKERS -t 0:$THREADS -b unix:%s'


### PR DESCRIPTION
## Description

Sinatra recommends using the [rerun gem](https://github.com/alexch/rerun) for auto-reloading.

I couldn't find an existing way to prefix the command when using puma-dev so this would add the ability to configure one.

If there aren't concerns with this approach I'd be happy to draft a usage paragraph for the README as well.

## Testing

Manually verified with the following `.pumaenv` file.
```
COMMAND_PREFIX="rerun --background --"
```